### PR TITLE
docs: organize AXIOM markdown documents into docs-axiom/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,7 @@
 .vscode/
 
 # Project docs (non-source)
-AXIOM-INSIGHTS.md
-AXIOM-SPEC.md
-AXIOM-ISSUES.md
-AXIOM-ROADMAP.md
+docs-axiom/
 
 # Python
 __pycache__/


### PR DESCRIPTION
## Summary
This PR organizes the various untracked AXIOM markdown documents into a central \docs-axiom/\ directory to declutter the root of the project.

## Changes
- Created the \docs-axiom/\ directory.
- Moved \AXIOM-INSIGHTS.md\, \AXIOM-ISSUES.md\, \AXIOM-ROADMAP.md\, and \AXIOM-SPEC.md\ into the new folder.
- Updated \.gitignore\ to ignore the \docs-axiom/\ directory instead of the individual files.

These files remain untracked as per the project's current configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to refine documentation file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->