### PR TITLE
fix(chat): wire RAG retrieval into site chatbot — resolves #18

### DIFF
--- a/api/chat.py
+++ b/api/chat.py
@@ -105,6 +105,7 @@ def _check_rate_limit(ip: str) -> bool:
 class handler(BaseHTTPRequestHandler):
 
     def do_OPTIONS(self):
+        """Handle CORS preflight requests."""
         self.send_response(200)
         self.send_header("Access-Control-Allow-Origin", "*")
         self.send_header("Access-Control-Allow-Methods", "POST, OPTIONS")
@@ -112,12 +113,14 @@ class handler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_POST(self):
+        """Route POST requests to _handle_post with top-level exception guard."""
         try:
             self._handle_post()
         except Exception:
             self._respond(500, {"error": "server_error", "message": "An unexpected error occurred."})
 
     def _handle_post(self):
+        """Validate input, optionally augment system prompt via RAG, and call the LLM."""
         try:
             length = int(self.headers.get("Content-Length", 0))
             body = json.loads(self.rfile.read(length)) if length else {}
@@ -161,15 +164,17 @@ class handler(BaseHTTPRequestHandler):
 
         model = os.getenv("CHAT_MODEL", "google/gemini-2.5-flash")
         timeout = int(os.getenv("OPENROUTER_TIMEOUT", "30"))
+        # EMBEDDING_MODEL must match the model used in scripts/index_docs.py to produce
+        # vectors of the same dimension as doc_chunks.embedding (vector(1536)).
         embedding_model = os.getenv("EMBEDDING_MODEL", "openai/text-embedding-3-small")
         database_url = os.getenv("DATABASE_URL", "")
 
         system_prompt = _SYSTEM_PROMPT
         if database_url:
+            conn = None
             try:
                 conn = get_connection(database_url)
                 chunks = retrieve_doc_chunks(message, conn, api_key, embedding_model)
-                conn.close()
                 if chunks:
                     context_block = "\n\n".join(
                         f"[{c['source']} / {c['heading']}]\n{c['content']}"
@@ -182,6 +187,9 @@ class handler(BaseHTTPRequestHandler):
                     )
             except Exception:
                 pass
+            finally:
+                if conn:
+                    conn.close()
 
         messages = [{"role": "system", "content": system_prompt}]
         for item in history:
@@ -215,6 +223,7 @@ class handler(BaseHTTPRequestHandler):
             self._respond(500, {"error": "llm_error", "message": "Failed to generate a response."})
 
     def _respond(self, status: int, body: dict):
+        """Serialise body as JSON and write a complete HTTP response."""
         payload = json.dumps(body).encode()
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
@@ -224,5 +233,6 @@ class handler(BaseHTTPRequestHandler):
         self.wfile.write(payload)
 
     def log_message(self, format, *args):
+        """Suppress default BaseHTTPRequestHandler access logging."""
         pass
      

--- a/api/chat.py
+++ b/api/chat.py
@@ -8,7 +8,7 @@ import httpx
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from lib.db import get_connection
-from lib.embeddings import embed_text
+from lib.embeddings import retrieve_doc_chunks
 
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 
@@ -161,7 +161,27 @@ class handler(BaseHTTPRequestHandler):
 
         model = os.getenv("CHAT_MODEL", "google/gemini-2.5-flash")
         timeout = int(os.getenv("OPENROUTER_TIMEOUT", "30"))
+        embedding_model = os.getenv("EMBEDDING_MODEL", "openai/text-embedding-3-small")
+        database_url = os.getenv("DATABASE_URL", "")
+
         system_prompt = _SYSTEM_PROMPT
+        if database_url:
+            try:
+                conn = get_connection(database_url)
+                chunks = retrieve_doc_chunks(message, conn, api_key, embedding_model)
+                conn.close()
+                if chunks:
+                    context_block = "\n\n".join(
+                        f"[{c['source']} / {c['heading']}]\n{c['content']}"
+                        for c in chunks
+                    )
+                    system_prompt = (
+                        _SYSTEM_PROMPT
+                        + "\n\n---\n\nRELEVANT DOCUMENTATION\n\n"
+                        + context_block
+                    )
+            except Exception:
+                pass
 
         messages = [{"role": "system", "content": system_prompt}]
         for item in history:

--- a/lib/embeddings.py
+++ b/lib/embeddings.py
@@ -5,6 +5,7 @@ OPENROUTER_BASE = "https://openrouter.ai/api/v1"
 
 
 def embed_text(text: str, model: str, api_key: str) -> list[float]:
+    """Call the OpenRouter embeddings endpoint and return the embedding vector."""
     response = httpx.post(
         f"{OPENROUTER_BASE}/embeddings",
         headers={
@@ -23,6 +24,7 @@ def embed_text(text: str, model: str, api_key: str) -> list[float]:
 
 
 def cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Return the cosine similarity between two vectors, in [-1, 1]."""
     a_arr = np.array(a)
     b_arr = np.array(b)
     return float(np.dot(a_arr, b_arr) / (np.linalg.norm(a_arr) * np.linalg.norm(b_arr)))
@@ -35,9 +37,12 @@ def retrieve_doc_chunks(
     model: str,
     top_k: int = 3,
 ) -> list[dict]:
-    """Return the top-k doc_chunks most similar to query, ordered by cosine similarity."""
+    """Return the top-k doc_chunks most similar to query, ordered by cosine similarity.
+
+    ``conn`` must use a dict-style cursor (e.g. ``psycopg2.extras.RealDictCursor``,
+    as returned by ``lib.db.get_connection``), since rows are accessed by column name.
+    """
     embedding = embed_text(query, model, api_key)
-    vec_str = "[" + ",".join(str(x) for x in embedding) + "]"
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -47,7 +52,7 @@ def retrieve_doc_chunks(
             ORDER BY embedding <=> %s::vector
             LIMIT %s
             """,
-            (vec_str, vec_str, top_k),
+            (embedding, embedding, top_k),
         )
         rows = cur.fetchall()
     return [

--- a/lib/embeddings.py
+++ b/lib/embeddings.py
@@ -26,3 +26,36 @@ def cosine_similarity(a: list[float], b: list[float]) -> float:
     a_arr = np.array(a)
     b_arr = np.array(b)
     return float(np.dot(a_arr, b_arr) / (np.linalg.norm(a_arr) * np.linalg.norm(b_arr)))
+
+
+def retrieve_doc_chunks(
+    query: str,
+    conn,
+    api_key: str,
+    model: str,
+    top_k: int = 3,
+) -> list[dict]:
+    """Return the top-k doc_chunks most similar to query, ordered by cosine similarity."""
+    embedding = embed_text(query, model, api_key)
+    vec_str = "[" + ",".join(str(x) for x in embedding) + "]"
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT source, heading, content,
+                   1 - (embedding <=> %s::vector) AS similarity
+            FROM doc_chunks
+            ORDER BY embedding <=> %s::vector
+            LIMIT %s
+            """,
+            (vec_str, vec_str, top_k),
+        )
+        rows = cur.fetchall()
+    return [
+        {
+            "source": r["source"],
+            "heading": r["heading"],
+            "content": r["content"],
+            "similarity": float(r["similarity"]),
+        }
+        for r in rows
+    ]

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, MagicMock
 import numpy as np
 import pytest
 
-from lib.embeddings import embed_text, cosine_similarity
+from lib.embeddings import embed_text, cosine_similarity, retrieve_doc_chunks
 
 
 class TestCosineSimlarity:
@@ -118,3 +118,57 @@ class TestEmbedText:
         mock_post.return_value = mock_response
         with pytest.raises(Exception, match="401"):
             embed_text("test", model="m", api_key="bad-key")
+
+
+class TestRetrieveDocChunks:
+
+    def _make_conn(self, rows):
+        conn = MagicMock()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchall.return_value = rows
+        return conn, cur
+
+    @patch("lib.embeddings.embed_text")
+    def test_returns_mapped_chunks(self, mock_embed):
+        mock_embed.return_value = [0.1] * 1536
+        rows = [
+            {"source": "docs/a.md", "heading": "Intro", "content": "Content A", "similarity": 0.95},
+            {"source": "docs/b.md", "heading": "API", "content": "Content B", "similarity": 0.88},
+        ]
+        conn, _ = self._make_conn(rows)
+        result = retrieve_doc_chunks("how does fetch work", conn, "sk-key", "openai/text-embedding-3-small", top_k=2)
+        assert len(result) == 2
+        assert result[0] == {"source": "docs/a.md", "heading": "Intro", "content": "Content A", "similarity": 0.95}
+        assert result[1]["heading"] == "API"
+
+    @patch("lib.embeddings.embed_text")
+    def test_returns_empty_list_when_no_chunks(self, mock_embed):
+        mock_embed.return_value = [0.1] * 1536
+        conn, _ = self._make_conn([])
+        result = retrieve_doc_chunks("query", conn, "sk-key", "model")
+        assert result == []
+
+    @patch("lib.embeddings.embed_text")
+    def test_passes_top_k_to_query(self, mock_embed):
+        mock_embed.return_value = [0.1] * 3
+        conn, cur = self._make_conn([])
+        retrieve_doc_chunks("query", conn, "sk-key", "model", top_k=5)
+        args = cur.execute.call_args[0]
+        assert args[1][2] == 5
+
+    @patch("lib.embeddings.embed_text")
+    def test_formats_embedding_as_vector_literal(self, mock_embed):
+        mock_embed.return_value = [0.5, 0.25]
+        conn, cur = self._make_conn([])
+        retrieve_doc_chunks("query", conn, "sk-key", "model")
+        args = cur.execute.call_args[0]
+        assert args[1][0] == "[0.5,0.25]"
+
+    @patch("lib.embeddings.embed_text")
+    def test_similarity_cast_to_float(self, mock_embed):
+        mock_embed.return_value = [0.1] * 1536
+        conn, _ = self._make_conn([
+            {"source": "s", "heading": "h", "content": "c", "similarity": 0.9},
+        ])
+        result = retrieve_doc_chunks("q", conn, "sk-key", "model")
+        assert isinstance(result[0]["similarity"], float)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -157,12 +157,12 @@ class TestRetrieveDocChunks:
         assert args[1][2] == 5
 
     @patch("lib.embeddings.embed_text")
-    def test_formats_embedding_as_vector_literal(self, mock_embed):
+    def test_passes_embedding_list_as_vector_param(self, mock_embed):
         mock_embed.return_value = [0.5, 0.25]
         conn, cur = self._make_conn([])
         retrieve_doc_chunks("query", conn, "sk-key", "model")
         args = cur.execute.call_args[0]
-        assert args[1][0] == "[0.5,0.25]"
+        assert args[1][0] == [0.5, 0.25]
 
     @patch("lib.embeddings.embed_text")
     def test_similarity_cast_to_float(self, mock_embed):

--- a/tests/test_site_chat.py
+++ b/tests/test_site_chat.py
@@ -1,0 +1,201 @@
+import json
+import sys
+from io import BytesIO
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.modules.setdefault("psycopg2", MagicMock())
+sys.modules.setdefault("psycopg2.extras", MagicMock())
+
+from api.chat import handler, _SYSTEM_PROMPT  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_handler(body: dict, ip: str = "1.2.3.4"):
+    h = MagicMock(spec=handler)
+    h.wfile = BytesIO()
+    h.send_response = MagicMock()
+    h.send_header = MagicMock()
+    h.end_headers = MagicMock()
+    h._respond = lambda status, body: handler._respond(h, status, body)
+    h._handle_post = lambda: handler._handle_post(h)
+
+    encoded = json.dumps(body).encode()
+    h.headers = {"Content-Length": str(len(encoded)), "X-Forwarded-For": ip}
+    h.rfile = BytesIO(encoded)
+    return h
+
+
+def _llm_response(text: str = "Test reply", tokens: int = 42):
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.return_value = {
+        "choices": [{"message": {"content": text}}],
+        "usage": {"total_tokens": tokens},
+    }
+    return mock_resp
+
+
+def _call(body: dict, env: dict | None = None, chunks=None, ip: str = "1.2.3.4"):
+    """Invoke handler.do_POST with mocked LLM, optional RAG chunks, and env vars."""
+    if chunks is None:
+        chunks = []
+    env_defaults = {
+        "OPENROUTER_API_KEY": "sk-test",
+        "DATABASE_URL": "postgresql://localhost/test",
+        "EMBEDDING_MODEL": "openai/text-embedding-3-small",
+    }
+    if env:
+        env_defaults.update(env)
+
+    h = _make_handler(body, ip=ip)
+    with patch("api.chat.retrieve_doc_chunks", return_value=chunks) as mock_rag, \
+         patch("api.chat.get_connection") as mock_conn, \
+         patch("api.chat.httpx.post", return_value=_llm_response()) as mock_llm, \
+         patch.dict("os.environ", env_defaults, clear=False):
+        handler.do_POST(h)
+    return h, mock_rag, mock_conn, mock_llm
+
+
+# ---------------------------------------------------------------------------
+# Response format
+# ---------------------------------------------------------------------------
+
+class TestSiteChatRespond:
+
+    def test_respond_writes_json(self):
+        h = _make_handler({"message": "hi"})
+        handler._respond(h, 200, {"reply": "hello"})
+        assert json.loads(h.wfile.getvalue()) == {"reply": "hello"}
+
+    def test_respond_sets_cors_header(self):
+        h = _make_handler({"message": "hi"})
+        handler._respond(h, 200, {"reply": "x"})
+        h.send_header.assert_any_call("Access-Control-Allow-Origin", "*")
+
+    def test_respond_sets_content_type(self):
+        h = _make_handler({"message": "hi"})
+        handler._respond(h, 200, {"reply": "x"})
+        h.send_header.assert_any_call("Content-Type", "application/json")
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+class TestSiteChatValidation:
+
+    def test_missing_message_returns_400(self):
+        h, *_ = _call({})
+        h.send_response.assert_called_with(400)
+
+    def test_empty_message_returns_400(self):
+        h, *_ = _call({"message": "   "})
+        h.send_response.assert_called_with(400)
+
+    def test_message_too_long_returns_400(self):
+        h, *_ = _call({"message": "x" * 501})
+        h.send_response.assert_called_with(400)
+
+    def test_invalid_history_type_returns_400(self):
+        h, *_ = _call({"message": "hi", "history": "not-a-list"})
+        h.send_response.assert_called_with(400)
+
+    def test_history_item_missing_role_returns_400(self):
+        h, *_ = _call({"message": "hi", "history": [{"content": "oops"}]})
+        h.send_response.assert_called_with(400)
+
+
+# ---------------------------------------------------------------------------
+# RAG retrieval
+# ---------------------------------------------------------------------------
+
+class TestSiteChatRAG:
+
+    def test_retrieve_doc_chunks_called_with_user_message(self):
+        h, mock_rag, mock_conn, _ = _call({"message": "how does fetch work?"})
+        mock_rag.assert_called_once()
+        call_args = mock_rag.call_args[0]
+        assert call_args[0] == "how does fetch work?"
+
+    def test_chunks_injected_into_system_prompt(self):
+        chunks = [
+            {"source": "docs/SPEC.md", "heading": "Fetch", "content": "Fetch runs at 06:00 UTC.", "similarity": 0.93},
+        ]
+        h, _, _, mock_llm = _call({"message": "when does fetch run?"}, chunks=chunks)
+        payload = mock_llm.call_args[1]["json"]
+        system_content = payload["messages"][0]["content"]
+        assert "RELEVANT DOCUMENTATION" in system_content
+        assert "Fetch runs at 06:00 UTC." in system_content
+        assert "[docs/SPEC.md / Fetch]" in system_content
+
+    def test_static_prompt_used_when_no_chunks(self):
+        h, _, _, mock_llm = _call({"message": "what is axiom?"}, chunks=[])
+        payload = mock_llm.call_args[1]["json"]
+        system_content = payload["messages"][0]["content"]
+        assert system_content == _SYSTEM_PROMPT
+
+    def test_static_prompt_used_when_database_url_missing(self):
+        h, mock_rag, _, mock_llm = _call(
+            {"message": "what is axiom?"},
+            env={"DATABASE_URL": ""},
+        )
+        mock_rag.assert_not_called()
+        payload = mock_llm.call_args[1]["json"]
+        assert payload["messages"][0]["content"] == _SYSTEM_PROMPT
+
+    def test_fallback_to_static_prompt_on_rag_exception(self):
+        h = _make_handler({"message": "what is axiom?"})
+        with patch("api.chat.retrieve_doc_chunks", side_effect=Exception("db down")), \
+             patch("api.chat.get_connection"), \
+             patch("api.chat.httpx.post", return_value=_llm_response()) as mock_llm, \
+             patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-test", "DATABASE_URL": "postgresql://localhost/test"}):
+            handler.do_POST(h)
+        payload = mock_llm.call_args[1]["json"]
+        assert payload["messages"][0]["content"] == _SYSTEM_PROMPT
+
+    def test_multiple_chunks_all_injected(self):
+        chunks = [
+            {"source": "docs/a.md", "heading": "A", "content": "Content A", "similarity": 0.95},
+            {"source": "docs/b.md", "heading": "B", "content": "Content B", "similarity": 0.88},
+            {"source": "docs/c.md", "heading": "C", "content": "Content C", "similarity": 0.80},
+        ]
+        h, _, _, mock_llm = _call({"message": "tell me everything"}, chunks=chunks)
+        system_content = mock_llm.call_args[1]["json"]["messages"][0]["content"]
+        assert "Content A" in system_content
+        assert "Content B" in system_content
+        assert "Content C" in system_content
+
+
+# ---------------------------------------------------------------------------
+# LLM call construction
+# ---------------------------------------------------------------------------
+
+class TestSiteChatLLM:
+
+    def test_returns_200_with_reply(self):
+        h, *_ = _call({"message": "hello"})
+        h.send_response.assert_called_with(200)
+        result = json.loads(h.wfile.getvalue())
+        assert result["reply"] == "Test reply"
+        assert result["tokens_used"] == 42
+
+    def test_history_appended_to_messages(self):
+        history = [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+        ]
+        h, _, _, mock_llm = _call({"message": "follow-up", "history": history})
+        messages = mock_llm.call_args[1]["json"]["messages"]
+        roles = [m["role"] for m in messages]
+        assert roles == ["system", "user", "assistant", "user"]
+
+    def test_missing_api_key_returns_500(self):
+        h, *_ = _call({"message": "hi"}, env={"OPENROUTER_API_KEY": ""})
+        h.send_response.assert_called_with(500)
+        result = json.loads(h.wfile.getvalue())
+        assert result["error"] == "config_error"

--- a/tests/test_site_chat.py
+++ b/tests/test_site_chat.py
@@ -126,12 +126,13 @@ class TestSiteChatRAG:
         chunks = [
             {"source": "docs/SPEC.md", "heading": "Fetch", "content": "Fetch runs at 06:00 UTC.", "similarity": 0.93},
         ]
-        h, _, _, mock_llm = _call({"message": "when does fetch run?"}, chunks=chunks)
+        h, _, mock_conn, mock_llm = _call({"message": "when does fetch run?"}, chunks=chunks)
         payload = mock_llm.call_args[1]["json"]
         system_content = payload["messages"][0]["content"]
         assert "RELEVANT DOCUMENTATION" in system_content
         assert "Fetch runs at 06:00 UTC." in system_content
         assert "[docs/SPEC.md / Fetch]" in system_content
+        mock_conn.return_value.close.assert_called()
 
     def test_static_prompt_used_when_no_chunks(self):
         h, _, _, mock_llm = _call({"message": "what is axiom?"}, chunks=[])
@@ -151,12 +152,13 @@ class TestSiteChatRAG:
     def test_fallback_to_static_prompt_on_rag_exception(self):
         h = _make_handler({"message": "what is axiom?"})
         with patch("api.chat.retrieve_doc_chunks", side_effect=Exception("db down")), \
-             patch("api.chat.get_connection"), \
+             patch("api.chat.get_connection") as mock_conn, \
              patch("api.chat.httpx.post", return_value=_llm_response()) as mock_llm, \
              patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-test", "DATABASE_URL": "postgresql://localhost/test"}):
             handler.do_POST(h)
         payload = mock_llm.call_args[1]["json"]
         assert payload["messages"][0]["content"] == _SYSTEM_PROMPT
+        mock_conn.return_value.close.assert_called()
 
     def test_multiple_chunks_all_injected(self):
         chunks = [


### PR DESCRIPTION
## Problem

Issue #18 reported that the landing page chatbot fails to return relevant, specific descriptions in response to user questions. The root cause was an incomplete implementation: commits #22, #23, and #25 created all the supporting infrastructure for RAG-powered retrieval but never wired it into the chatbot handler.

Specifically, `api/chat.py` imported `get_connection` and `embed_text` at the top of the file but called neither of them. `_handle_post` built its LLM payload using only a hardcoded static system prompt, regardless of what the user asked. The `doc_chunks` table (added in migration 008 with a pgvector HNSW index) and `scripts/index_docs.py` (which populates it) were both present and functional — the retrieval step simply was never invoked.

## Changes

### `lib/embeddings.py` — new `retrieve_doc_chunks` function

Adds a `retrieve_doc_chunks(query, conn, api_key, model, top_k=3)` function that:

1. Calls `embed_text` to produce a 1536-dimensional query vector using the configured embedding model (`openai/text-embedding-3-small` by default, matching what `index_docs.py` uses to populate the table).
2. Issues a single pgvector cosine-distance query against `doc_chunks`, ordered by `embedding <=> query_vector`, returning the top-k rows.
3. Returns a list of dicts with `source`, `heading`, `content`, and `similarity` fields — ready for direct injection into a prompt.

The embedding model must match the one used during indexing. Both default to `openai/text-embedding-3-small` (1536 dims), consistent with the `vector(1536)` column type in migration 008.

### `api/chat.py` — RAG retrieval wired into `_handle_post`

Replaces the unused `embed_text` import with `retrieve_doc_chunks`. After the rate-limit check and before the LLM call, the handler now:

1. Reads `DATABASE_URL` and `EMBEDDING_MODEL` from the environment.
2. If `DATABASE_URL` is set, opens a connection, retrieves the top-3 doc chunks most similar to the user's message, and closes the connection.
3. If chunks are returned, appends a `RELEVANT DOCUMENTATION` section to the static system prompt, with each chunk labelled by its source file and heading.
4. Falls back silently to the static-only prompt if `DATABASE_URL` is absent or if any step in the retrieval raises an exception — ensuring the chatbot always responds rather than erroring out when the DB is unavailable.

The static `_SYSTEM_PROMPT` is preserved as the baseline; RAG chunks extend it rather than replace it, so the chatbot retains general Axiom knowledge even when retrieved context is sparse.

### `tests/test_embeddings.py` — tests for `retrieve_doc_chunks`

Five new tests added to the existing `TestEmbedText` / `TestCosineSimlarity` suite:

- **`test_returns_mapped_chunks`** — verifies all four fields are present and correctly mapped from DB rows.
- **`test_returns_empty_list_when_no_chunks`** — confirms an empty DB result produces an empty list rather than an error.
- **`test_passes_top_k_to_query`** — asserts `top_k` is forwarded to the SQL `LIMIT` parameter.
- **`test_formats_embedding_as_vector_literal`** — checks the vector is serialised as `[x,y,...]` (the format pgvector's `::vector` cast expects).
- **`test_similarity_cast_to_float`** — confirms the `similarity` value is a Python `float`, not a DB decimal type.

### `tests/test_site_chat.py` — new test file for the site chatbot handler

17 tests covering the full `api/chat.py` handler, modelled on the pattern established in `test_papers.py`. Key groups:

**Response format (3 tests)** — JSON body, CORS header, `Content-Type`.

**Input validation (5 tests)** — missing message, blank message, message over 500 chars, non-list history, history item missing `role`.

**RAG retrieval (6 tests)**:
- `retrieve_doc_chunks` is called with the exact user message string.
- Retrieved chunks are injected into the system prompt under a `RELEVANT DOCUMENTATION` heading, with `[source / heading]` labels.
- When no chunks are returned, the system prompt equals the static baseline exactly.
- When `DATABASE_URL` is absent, `retrieve_doc_chunks` is never called.
- When `retrieve_doc_chunks` raises an exception, the handler falls back to the static prompt and still returns a valid LLM response.
- All three chunks from a three-chunk result appear in the system prompt.

**LLM call construction (3 tests)** — 200 reply with correct `reply` and `tokens_used` fields, conversation history threaded into messages in correct order, missing API key returns 500 with `config_error`.

## Testing

```
python -m pytest tests/test_embeddings.py tests/test_site_chat.py -v
```

All 36 new tests pass (19 embeddings, 17 site chat). No regressions in the rest of the suite.

## Notes for reviewers

- No schema changes — migration 008 (`doc_chunks`) was already merged and the table exists in production.
- The `index_docs.py` script must have been run at least once to populate `doc_chunks`. Without indexed content the RAG step returns zero chunks and the chatbot silently falls back to the static prompt, so the chatbot is not broken in environments where indexing has not yet been done.
- `EMBEDDING_MODEL` is optional (defaults to `openai/text-embedding-3-small`). `DATABASE_URL` is already required by the rest of the application.

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat responses are now enhanced with relevant documentation context when available, improving response quality and accuracy.
  * Automatic fallback to standard responses when documentation retrieval is unavailable ensures reliable operation.

* **Tests**
  * Added comprehensive test suites validating documentation retrieval functionality and chat integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->