### PR TITLE
fix: RAG DB connection handling and embedding test assertions

### DIFF
--- a/api/chat.py
+++ b/api/chat.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 import time
+from contextlib import closing
 from http.server import BaseHTTPRequestHandler
 
 import httpx
@@ -171,25 +172,21 @@ class handler(BaseHTTPRequestHandler):
 
         system_prompt = _SYSTEM_PROMPT
         if database_url:
-            conn = None
             try:
-                conn = get_connection(database_url)
-                chunks = retrieve_doc_chunks(message, conn, api_key, embedding_model)
-                if chunks:
-                    context_block = "\n\n".join(
-                        f"[{c['source']} / {c['heading']}]\n{c['content']}"
-                        for c in chunks
-                    )
-                    system_prompt = (
-                        _SYSTEM_PROMPT
-                        + "\n\n---\n\nRELEVANT DOCUMENTATION\n\n"
-                        + context_block
-                    )
+                with closing(get_connection(database_url)) as conn:
+                    chunks = retrieve_doc_chunks(message, conn, api_key, embedding_model)
+                    if chunks:
+                        context_block = "\n\n".join(
+                            f"[{c['source']} / {c['heading']}]\n{c['content']}"
+                            for c in chunks
+                        )
+                        system_prompt = (
+                            _SYSTEM_PROMPT
+                            + "\n\n---\n\nRELEVANT DOCUMENTATION\n\n"
+                            + context_block
+                        )
             except Exception:
                 pass
-            finally:
-                if conn:
-                    conn.close()
 
         messages = [{"role": "system", "content": system_prompt}]
         for item in history:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -158,11 +158,15 @@ class TestRetrieveDocChunks:
 
     @patch("lib.embeddings.embed_text")
     def test_passes_embedding_list_as_vector_param(self, mock_embed):
+        # psycopg2 + pgvector expect bound parameters as Python list[float], not
+        # a pre-formatted string literal (e.g. "[0.5,0.25]") in the param tuple.
         mock_embed.return_value = [0.5, 0.25]
         conn, cur = self._make_conn([])
         retrieve_doc_chunks("query", conn, "sk-key", "model")
         args = cur.execute.call_args[0]
-        assert args[1][0] == [0.5, 0.25]
+        first_arg = args[1][0]
+        assert not isinstance(first_arg, str)
+        assert first_arg == [0.5, 0.25]
 
     @patch("lib.embeddings.embed_text")
     def test_similarity_cast_to_float(self, mock_embed):


### PR DESCRIPTION
## Summary

- **Site chat RAG:** Use \contextlib.closing\ around \get_connection()\ in \pi/chat.py\ so the database connection is always released when the RAG path runs, including on exceptions.
- **Tests:** In \	est_passes_embedding_list_as_vector_param\, document that pgvector parameters are passed as Python lists (bound params), not as string literals; assert the first execute arg is not a str.