### PR TITLE
fix: resolve silent daily delivery failures caused by Vercel function timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,9 @@ QUALITY_GATE_MIN=13             # Min combined novelty + feasibility score
 DEDUP_SIMILARITY_MAX=0.80       # Max similarity to any previously sent idea
 
 # Delivery config
-MAX_IDEAS_PER_DAY=2             # Max ideas sent per daily deliver run
+MAX_IDEAS_PER_DAY=2             # Ideas delivered per day (one per cron run, two runs scheduled)
+DELIVER_LLM_TIMEOUT=50          # Per-attempt LLM timeout for the deliver cron (s). Keep ≤80.
+OPENROUTER_TIMEOUT=90           # LLM timeout for /spark and chat (s)
 
 # Chat feature
 CHAT_ENABLED=true

--- a/api/deliver.py
+++ b/api/deliver.py
@@ -160,6 +160,7 @@ def run_deliver(cfg) -> dict:
         idea_id = store_idea(conn, paper_id, idea, idea_embedding)
 
         # Send to all active users
+        failed_users = []
         for user_id in active_users:
             try:
                 send_idea_message(
@@ -173,6 +174,7 @@ def run_deliver(cfg) -> dict:
                 print(f"[deliver] sent to user {user_id}")
             except Exception as e:
                 print(f"[deliver] failed to send to user {user_id}: {e}")
+                failed_users.append(user_id)
 
         mark_processed(conn, paper_id)
         _notify_owner(cfg, status="sent", idea_id=idea_id, paper_id=paper_id, model=model)
@@ -187,7 +189,9 @@ def run_deliver(cfg) -> dict:
                     "llm_parse_error": 0,
                     "below_quality_gate": 0,
                     "duplicate_idea": 0,
-                }
+                },
+                "users_notified": len(active_users) - len(failed_users),
+                "send_failures": len(failed_users),
             },
         }
     finally:

--- a/api/deliver.py
+++ b/api/deliver.py
@@ -5,7 +5,7 @@ from http.server import BaseHTTPRequestHandler
 from lib.config import load_config
 from lib.openrouter import synthesize_idea
 from lib.embeddings import embed_text
-from lib.telegram_client import send_idea_message
+from lib.telegram_client import send_idea_message, send_message
 from lib.db import get_connection
 
 
@@ -50,25 +50,16 @@ class handler(BaseHTTPRequestHandler):
 def run_deliver(cfg) -> dict:
     conn = get_connection(cfg.database_url)
     try:
-        sent_count = 0
-        processed_papers = []
-        skipped_details = {
-            "llm_parse_error": 0,
-            "below_quality_gate": 0,
-            "duplicate_idea": 0
-        }
-
         with conn.cursor() as cur:
-            # Fetch top unprocessed papers by relevance score
+            # Fetch the single highest-scored unprocessed paper
             cur.execute(
                 """SELECT id, title, abstract, url
                    FROM papers
                    WHERE NOT processed AND NOT skipped
                    ORDER BY relevance_score DESC
-                   LIMIT %s""",
-                (cfg.max_ideas_per_day * 2,),  # fetch extra in case some fail quality gate
+                   LIMIT 1""",
             )
-            papers = cur.fetchall()
+            paper = cur.fetchone()
 
             # Fetch active authorized users
             cur.execute(
@@ -98,16 +89,19 @@ def run_deliver(cfg) -> dict:
                 )
                 active_users = [row["user_id"] for row in cur.fetchall()]
 
-        print(f"[deliver] found {len(papers)} papers, {len(active_users)} active users")
+        print(f"[deliver] candidate paper: {paper['id'] if paper else None}, "
+              f"{len(active_users)} active users")
 
-        if not papers or not active_users:
-            print(f"[deliver] early exit: no papers or no active users")
+        if not paper or not active_users:
+            reason = "no papers or no active users"
+            print(f"[deliver] early exit: {reason}")
+            _notify_owner(cfg, status="skipped", reason=reason)
             return {
                 "sent": 0,
-                "reason": "no papers or no active users",
+                "reason": reason,
                 "stats": {
-                    "papers_found": len(papers),
-                    "active_users": len(active_users)
+                    "papers_found": 1 if paper else 0,
+                    "active_users": len(active_users),
                 }
             }
 
@@ -115,90 +109,110 @@ def run_deliver(cfg) -> dict:
         model = cfg.deepdive_model if datetime.utcnow().weekday() == cfg.deepdive_day \
                 else cfg.default_model
 
-        for paper in papers:
-            if sent_count >= cfg.max_ideas_per_day:
-                print(f"[deliver] reached max_ideas_per_day limit ({cfg.max_ideas_per_day})")
-                break
+        paper_id = paper["id"]
+        title = paper["title"]
+        abstract = paper["abstract"]
+        url = paper["url"]
 
-            paper_id = paper["id"]
-            title = paper["title"]
-            abstract = paper["abstract"]
-            url = paper["url"]
+        print(f"[deliver] processing paper: {title[:60]}...")
 
-            print(f"[deliver] processing paper: {title[:60]}...")
+        idea, _ = synthesize_idea(
+            title=title,
+            abstract=abstract,
+            model=model,
+            api_key=cfg.openrouter_api_key,
+            fallback_model=cfg.fallback_model,
+            timeout=cfg.deliver_llm_timeout,
+        )
 
-            idea, _ = synthesize_idea(
-                title=title,
-                abstract=abstract,
-                model=model,
+        if idea is None:
+            print(f"[deliver] skipped (llm_parse_error): {paper_id}")
+            mark_processed(conn, paper_id, skip_reason="llm_parse_error")
+            _notify_owner(cfg, status="skipped", reason="llm_parse_error", paper_id=paper_id)
+            return {"sent": 0, "details": {"skipped": {"llm_parse_error": 1}}}
+
+        # Quality gate
+        if idea["novelty_score"] + idea["feasibility_score"] < cfg.quality_gate_min:
+            score = idea["novelty_score"] + idea["feasibility_score"]
+            print(f"[deliver] skipped (below_quality_gate): {paper_id} (score: {score})")
+            mark_processed(conn, paper_id, skip_reason="below_quality_gate")
+            _notify_owner(cfg, status="skipped", reason="below_quality_gate", paper_id=paper_id)
+            return {"sent": 0, "details": {"skipped": {"below_quality_gate": 1}}}
+
+        # Dedup check against previously sent ideas
+        try:
+            idea_embedding = embed_text(
+                idea["hypothesis"] + " " + idea["method"],
+                model=cfg.embedding_model,
                 api_key=cfg.openrouter_api_key,
-                fallback_model=cfg.fallback_model,
-                timeout=cfg.openrouter_timeout,
             )
+        except Exception as e:
+            print(f"[deliver] embedding failed, storing without: {e}")
+            idea_embedding = None
 
-            if idea is None:
-                print(f"[deliver] skipped (llm_parse_error): {paper_id}")
-                mark_processed(conn, paper_id, skip_reason="llm_parse_error")
-                skipped_details["llm_parse_error"] += 1
-                continue
+        if idea_embedding is not None and is_duplicate(conn, idea_embedding, cfg.dedup_similarity_max):
+            print(f"[deliver] skipped (duplicate_idea): {paper_id}")
+            mark_processed(conn, paper_id, skip_reason="duplicate_idea")
+            _notify_owner(cfg, status="skipped", reason="duplicate_idea", paper_id=paper_id)
+            return {"sent": 0, "details": {"skipped": {"duplicate_idea": 1}}}
 
-            # Quality gate
-            if idea["novelty_score"] + idea["feasibility_score"] < cfg.quality_gate_min:
-                print(f"[deliver] skipped (below_quality_gate): {paper_id} (score: {idea['novelty_score'] + idea['feasibility_score']})")
-                mark_processed(conn, paper_id, skip_reason="below_quality_gate")
-                skipped_details["below_quality_gate"] += 1
-                continue
+        # Persist idea
+        idea_id = store_idea(conn, paper_id, idea, idea_embedding)
 
-            # Dedup check against previously sent ideas
+        # Send to all active users
+        for user_id in active_users:
             try:
-                idea_embedding = embed_text(
-                    idea["hypothesis"] + " " + idea["method"],
-                    model=cfg.embedding_model,
-                    api_key=cfg.openrouter_api_key,
+                send_idea_message(
+                    chat_id=user_id,
+                    idea_id=idea_id,
+                    title=title,
+                    url=url,
+                    idea=idea,
+                    bot_token=cfg.telegram_bot_token,
                 )
+                print(f"[deliver] sent to user {user_id}")
             except Exception as e:
-                print(f"[deliver] embedding failed, storing without: {e}")
-                idea_embedding = None
+                print(f"[deliver] failed to send to user {user_id}: {e}")
 
-            if idea_embedding is not None and is_duplicate(conn, idea_embedding, cfg.dedup_similarity_max):
-                print(f"[deliver] skipped (duplicate_idea): {paper_id}")
-                mark_processed(conn, paper_id, skip_reason="duplicate_idea")
-                skipped_details["duplicate_idea"] += 1
-                continue
-
-            # Persist idea
-            idea_id = store_idea(conn, paper_id, idea, idea_embedding)
-
-            # Send to all active users
-            for user_id in active_users:
-                try:
-                    send_idea_message(
-                        chat_id=user_id,
-                        idea_id=idea_id,
-                        title=title,
-                        url=url,
-                        idea=idea,
-                        bot_token=cfg.telegram_bot_token,
-                    )
-                    print(f"[deliver] sent to user {user_id}")
-                except Exception as e:
-                    print(f"[deliver] failed to send to user {user_id}: {e}")
-
-            mark_processed(conn, paper_id)
-            sent_count += 1
-            processed_papers.append(paper_id)
-            print(f"[deliver] successfully processed and sent idea {idea_id}")
+        mark_processed(conn, paper_id)
+        _notify_owner(cfg, status="sent", idea_id=idea_id, paper_id=paper_id, model=model)
+        print(f"[deliver] successfully processed and sent idea {idea_id}")
 
         return {
-            "sent": sent_count,
-            "papers": processed_papers,
+            "sent": 1,
+            "papers": [paper_id],
             "model": model,
             "details": {
-                "skipped": skipped_details
-            }
+                "skipped": {
+                    "llm_parse_error": 0,
+                    "below_quality_gate": 0,
+                    "duplicate_idea": 0,
+                }
+            },
         }
     finally:
         conn.close()
+
+
+def _notify_owner(cfg, status: str, **details) -> None:
+    """Best-effort Telegram ping to all owner IDs. Never raises."""
+    import datetime as _dt
+    ts = _dt.datetime.utcnow().strftime("%H:%M UTC")
+    if status == "sent":
+        text = (
+            f"[Axiom] Delivered idea #{details.get('idea_id', '?')} at {ts}.\n"
+            f"Paper: {details.get('paper_id', '?')} | Model: {details.get('model', '?')}"
+        )
+    else:
+        text = (
+            f"[Axiom] Delivery skipped at {ts}.\n"
+            f"Reason: {details.get('reason', 'unknown')} | Paper: {details.get('paper_id', 'N/A')}"
+        )
+    for chat_id in cfg.telegram_chat_ids:
+        try:
+            send_message(chat_id, text, cfg.telegram_bot_token)
+        except Exception as e:
+            print(f"[deliver] _notify_owner failed for {chat_id}: {e}")
 
 
 def mark_processed(conn, paper_id: str, skip_reason: str = None):

--- a/lib/config.py
+++ b/lib/config.py
@@ -24,6 +24,7 @@ class Config:
     embedding_model: str
     max_ideas_per_day: int
     openrouter_timeout: int
+    deliver_llm_timeout: int
 
     # Chat feature settings
     chat_enabled: bool
@@ -71,6 +72,7 @@ def load_config() -> Config:
         embedding_model=os.getenv("EMBEDDING_MODEL", "openai/text-embedding-3-small"),
         max_ideas_per_day=int(os.getenv("MAX_IDEAS_PER_DAY", "2")),
         openrouter_timeout=int(os.getenv("OPENROUTER_TIMEOUT", "90")),
+        deliver_llm_timeout=int(os.getenv("DELIVER_LLM_TIMEOUT", "50")),
 
         # Chat feature
         chat_enabled=os.getenv("CHAT_ENABLED", "true").lower() == "true",

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -11,7 +11,7 @@ sys.modules.setdefault("psycopg2", MagicMock())
 sys.modules.setdefault("psycopg2.extras", MagicMock())
 
 from api.deliver import (  # noqa: E402
-    handler, run_deliver, mark_processed, is_duplicate, store_idea,
+    handler, run_deliver, mark_processed, is_duplicate, store_idea, _notify_owner,
 )
 
 
@@ -39,6 +39,7 @@ def _make_config(**overrides):
         "database_url": "postgresql://localhost/test",
         "openrouter_api_key": "or-key",
         "default_model": "google/gemini-flash-1.5",
+        "fallback_model": "google/gemini-2.0-flash",
         "deepdive_model": "anthropic/claude-haiku",
         "deepdive_day": 4,
         "cron_secret": "my-secret",
@@ -51,6 +52,7 @@ def _make_config(**overrides):
         "embedding_model": "openai/text-embedding-3-small",
         "max_ideas_per_day": 2,
         "openrouter_timeout": 90,
+        "deliver_llm_timeout": 50,
     }
     defaults.update(overrides)
     cfg = MagicMock()
@@ -73,11 +75,11 @@ def _make_idea(novelty=7, feasibility=8):
     }
 
 
-def _mock_conn_with_papers(papers, users):
-    """Create a mock connection that returns papers then users from two fetchall calls."""
+def _mock_conn_with_papers(paper, users):
+    """Create a mock connection returning a single paper via fetchone and users via fetchall."""
     mock_cursor = MagicMock()
-    mock_cursor.fetchall.side_effect = [papers, [{"user_id": u} for u in users]]
-    mock_cursor.fetchone.return_value = {"id": 1}  # for store_idea RETURNING id
+    mock_cursor.fetchone.side_effect = [paper, {"id": 1}]  # paper query, store_idea RETURNING id
+    mock_cursor.fetchall.return_value = [{"user_id": u} for u in users]
     mock_conn = MagicMock()
     mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
@@ -238,7 +240,7 @@ class TestRunDeliverEarlyExit:
 
     @patch("api.deliver.get_connection")
     def test_no_papers_returns_zero(self, mock_get_conn):
-        mock_conn = _mock_conn_with_papers(papers=[], users=[123])
+        mock_conn = _mock_conn_with_papers(paper=None, users=[123])
         mock_get_conn.return_value = mock_conn
         cfg = _make_config()
         result = run_deliver(cfg)
@@ -249,7 +251,7 @@ class TestRunDeliverEarlyExit:
 
     @patch("api.deliver.get_connection")
     def test_no_users_returns_zero(self, mock_get_conn):
-        mock_conn = _mock_conn_with_papers(papers=[_make_paper()], users=[])
+        mock_conn = _mock_conn_with_papers(paper=_make_paper(), users=[])
         mock_get_conn.return_value = mock_conn
         cfg = _make_config()
         result = run_deliver(cfg)
@@ -274,7 +276,7 @@ class TestRunDeliverModelSelection:
                                                mock_synth, mock_embed,
                                                mock_dedup, mock_store, mock_send):
         mock_dt.utcnow.return_value = datetime(2024, 1, 15)  # Monday (weekday=0)
-        mock_conn = _mock_conn_with_papers([_make_paper()], [123])
+        mock_conn = _mock_conn_with_papers(_make_paper(), [123])
         mock_conn_fn.return_value = mock_conn
         mock_synth.return_value = (_make_idea(), "")
         cfg = _make_config(deepdive_day=4)
@@ -292,7 +294,7 @@ class TestRunDeliverModelSelection:
                                                     mock_synth, mock_embed,
                                                     mock_dedup, mock_store, mock_send):
         mock_dt.utcnow.return_value = datetime(2024, 1, 19)  # Friday (weekday=4)
-        mock_conn = _mock_conn_with_papers([_make_paper()], [123])
+        mock_conn = _mock_conn_with_papers(_make_paper(), [123])
         mock_conn_fn.return_value = mock_conn
         mock_synth.return_value = (_make_idea(), "")
         cfg = _make_config(deepdive_day=4)
@@ -313,7 +315,7 @@ class TestRunDeliverSkipReasons:
     def test_llm_parse_error_marks_processed(self, mock_dt, mock_conn_fn,
                                               mock_synth, mock_mark):
         mock_dt.utcnow.return_value = datetime(2024, 1, 15)
-        mock_conn = _mock_conn_with_papers([_make_paper()], [123])
+        mock_conn = _mock_conn_with_papers(_make_paper(), [123])
         mock_conn_fn.return_value = mock_conn
         cfg = _make_config()
         run_deliver(cfg)
@@ -326,7 +328,7 @@ class TestRunDeliverSkipReasons:
     def test_below_quality_gate_marks_processed(self, mock_dt, mock_conn_fn,
                                                  mock_synth, mock_mark):
         mock_dt.utcnow.return_value = datetime(2024, 1, 15)
-        mock_conn = _mock_conn_with_papers([_make_paper()], [123])
+        mock_conn = _mock_conn_with_papers(_make_paper(), [123])
         mock_conn_fn.return_value = mock_conn
         mock_synth.return_value = (_make_idea(novelty=3, feasibility=4), "")  # 7 < 13
         cfg = _make_config(quality_gate_min=13)
@@ -343,7 +345,7 @@ class TestRunDeliverSkipReasons:
                                              mock_synth, mock_embed,
                                              mock_dedup, mock_mark):
         mock_dt.utcnow.return_value = datetime(2024, 1, 15)
-        mock_conn = _mock_conn_with_papers([_make_paper()], [123])
+        mock_conn = _mock_conn_with_papers(_make_paper(), [123])
         mock_conn_fn.return_value = mock_conn
         mock_synth.return_value = (_make_idea(), "")
         cfg = _make_config()
@@ -369,7 +371,7 @@ class TestRunDeliverSuccess:
                                         mock_synth, mock_embed,
                                         mock_dedup, mock_store, mock_send, mock_mark):
         mock_dt.utcnow.return_value = datetime(2024, 1, 15)
-        mock_conn = _mock_conn_with_papers([_make_paper()], [100, 200, 300])
+        mock_conn = _mock_conn_with_papers(_make_paper(), [100, 200, 300])
         mock_conn_fn.return_value = mock_conn
         mock_synth.return_value = (_make_idea(), "")
         cfg = _make_config()
@@ -387,18 +389,17 @@ class TestRunDeliverSuccess:
     @patch("api.deliver.synthesize_idea")
     @patch("api.deliver.get_connection")
     @patch("api.deliver.datetime")
-    def test_respects_max_ideas_per_day(self, mock_dt, mock_conn_fn,
-                                         mock_synth, mock_embed,
-                                         mock_dedup, mock_store, mock_send, mock_mark):
+    def test_single_run_sends_exactly_one_paper(self, mock_dt, mock_conn_fn,
+                                                 mock_synth, mock_embed,
+                                                 mock_dedup, mock_store, mock_send, mock_mark):
         mock_dt.utcnow.return_value = datetime(2024, 1, 15)
-        papers = [_make_paper(id=f"p{i}") for i in range(5)]
-        mock_conn = _mock_conn_with_papers(papers, [123])
+        mock_conn = _mock_conn_with_papers(_make_paper(id="p1"), [123])
         mock_conn_fn.return_value = mock_conn
         mock_synth.return_value = (_make_idea(), "")
-        cfg = _make_config(max_ideas_per_day=2)
+        cfg = _make_config()
         result = run_deliver(cfg)
-        assert result["sent"] == 2
-        assert len(result["papers"]) == 2
+        assert result["sent"] == 1
+        assert result["papers"] == ["p1"]
 
     @patch("api.deliver.mark_processed")
     @patch("api.deliver.send_idea_message")
@@ -412,12 +413,86 @@ class TestRunDeliverSuccess:
                                           mock_synth, mock_embed,
                                           mock_dedup, mock_store, mock_send, mock_mark):
         mock_dt.utcnow.return_value = datetime(2024, 1, 15)
-        mock_conn = _mock_conn_with_papers([_make_paper(id="2401.99999")], [123])
+        mock_conn = _mock_conn_with_papers(_make_paper(id="2401.99999"), [123])
         mock_conn_fn.return_value = mock_conn
         mock_synth.return_value = (_make_idea(), "")
         cfg = _make_config()
         result = run_deliver(cfg)
         assert "2401.99999" in result["papers"]
+
+
+# ---------------------------------------------------------------------------
+# run_deliver: deliver_llm_timeout is used (not openrouter_timeout)
+# ---------------------------------------------------------------------------
+
+class TestRunDeliverTimeout:
+
+    @patch("api.deliver._notify_owner")
+    @patch("api.deliver.mark_processed")
+    @patch("api.deliver.synthesize_idea", return_value=(None, "error"))
+    @patch("api.deliver.get_connection")
+    @patch("api.deliver.datetime")
+    def test_uses_deliver_llm_timeout_not_openrouter_timeout(
+            self, mock_dt, mock_get_conn, mock_synth, mock_mark, mock_notify):
+        mock_dt.utcnow.return_value = datetime(2024, 1, 15)
+        mock_conn = _mock_conn_with_papers(_make_paper(), [123])
+        mock_get_conn.return_value = mock_conn
+        cfg = _make_config(deliver_llm_timeout=42, openrouter_timeout=90)
+        run_deliver(cfg)
+        _, kwargs = mock_synth.call_args
+        assert kwargs["timeout"] == 42
+
+    @patch("api.deliver._notify_owner")
+    @patch("api.deliver.mark_processed")
+    @patch("api.deliver.synthesize_idea", return_value=(None, "error"))
+    @patch("api.deliver.get_connection")
+    @patch("api.deliver.datetime")
+    def test_openrouter_timeout_not_passed_to_deliver(
+            self, mock_dt, mock_get_conn, mock_synth, mock_mark, mock_notify):
+        """openrouter_timeout (90s) must never be used as the deliver LLM timeout."""
+        mock_dt.utcnow.return_value = datetime(2024, 1, 15)
+        mock_conn = _mock_conn_with_papers(_make_paper(), [123])
+        mock_get_conn.return_value = mock_conn
+        cfg = _make_config(deliver_llm_timeout=50, openrouter_timeout=90)
+        run_deliver(cfg)
+        _, kwargs = mock_synth.call_args
+        assert kwargs["timeout"] != 90
+
+
+# ---------------------------------------------------------------------------
+# _notify_owner
+# ---------------------------------------------------------------------------
+
+class TestNotifyOwner:
+
+    @patch("api.deliver.send_message")
+    def test_sends_to_all_telegram_chat_ids(self, mock_send):
+        cfg = _make_config(telegram_chat_ids=[111, 222])
+        _notify_owner(cfg, status="sent", idea_id=5, paper_id="2401.1234", model="gemini")
+        assert mock_send.call_count == 2
+        chat_ids_called = [c[0][0] for c in mock_send.call_args_list]
+        assert sorted(chat_ids_called) == [111, 222]
+
+    @patch("api.deliver.send_message")
+    def test_sent_message_contains_idea_id(self, mock_send):
+        cfg = _make_config(telegram_chat_ids=[1])
+        _notify_owner(cfg, status="sent", idea_id=99, paper_id="p1", model="m")
+        text = mock_send.call_args[0][1]
+        assert "99" in text
+
+    @patch("api.deliver.send_message")
+    def test_skipped_message_contains_reason(self, mock_send):
+        cfg = _make_config(telegram_chat_ids=[1])
+        _notify_owner(cfg, status="skipped", reason="below_quality_gate", paper_id="p1")
+        text = mock_send.call_args[0][1]
+        assert "below_quality_gate" in text
+
+    @patch("api.deliver.send_message", side_effect=Exception("network error"))
+    def test_swallows_send_errors(self, mock_send):
+        """_notify_owner must never raise even if send_message fails."""
+        cfg = _make_config(telegram_chat_ids=[111])
+        _notify_owner(cfg, status="sent", idea_id=1, paper_id="p1", model="m")
+        # Reached here without raising — test passes
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -78,7 +78,8 @@ def _make_idea(novelty=7, feasibility=8):
 def _mock_conn_with_papers(paper, users):
     """Create a mock connection returning a single paper via fetchone and users via fetchall."""
     mock_cursor = MagicMock()
-    mock_cursor.fetchone.side_effect = [paper, {"id": 1}]  # paper query, store_idea RETURNING id
+    # fetchone call order: 1) paper SELECT query, 2) store_idea INSERT RETURNING id
+    mock_cursor.fetchone.side_effect = [paper, {"id": 1}]
     mock_cursor.fetchall.return_value = [{"user_id": u} for u in users]
     mock_conn = MagicMock()
     mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)

--- a/vercel.json
+++ b/vercel.json
@@ -21,8 +21,12 @@
     { "src": "/favicon.svg",  "dest": "/favicon.svg" },
     { "src": "/(.*)",         "dest": "/public/$1" }
   ],
+  "functions": {
+    "api/deliver.py": { "maxDuration": 300 }
+  },
   "crons": [
     { "path": "/api/fetch",   "schedule": "0 6 * * *" },
-    { "path": "/api/deliver", "schedule": "0 8 * * *" }
+    { "path": "/api/deliver", "schedule": "0 8 * * *" },
+    { "path": "/api/deliver", "schedule": "0 9 * * *" }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "builds": [
     { "src": "api/fetch.py",    "use": "@vercel/python" },
-    { "src": "api/deliver.py",  "use": "@vercel/python" },
+    { "src": "api/deliver.py",  "use": "@vercel/python", "config": { "maxDuration": 300 } },
     { "src": "api/telegram.py", "use": "@vercel/python" },
     { "src": "api/spark.py",    "use": "@vercel/python" },
     { "src": "api/status.py",   "use": "@vercel/python" },
@@ -21,9 +21,6 @@
     { "src": "/favicon.svg",  "dest": "/favicon.svg" },
     { "src": "/(.*)",         "dest": "/public/$1" }
   ],
-  "functions": {
-    "api/deliver.py": { "maxDuration": 300 }
-  },
   "crons": [
     { "path": "/api/fetch",   "schedule": "0 6 * * *" },
     { "path": "/api/deliver", "schedule": "0 8 * * *" },


### PR DESCRIPTION
## Problem

Daily idea delivery has never worked. The cron jobs at 08:00 UTC call \`/api/deliver\`, which was silently killed by Vercel's function runtime on every invocation before it could send anything.

The authentication fix (Bearer token support) was shipped earlier and works correctly. The remaining root cause, noted as \"Still open\" in \`docs-axiom/AXIOM-ISSUES.md\`, is a budget mismatch:

- \`run_deliver()\` looped over up to \`max_ideas_per_day * 2\` papers
- Each paper called \`synthesize_idea()\` with \`OPENROUTER_TIMEOUT=90s\` and \`max_retries=2\`
- Worst case per paper: \`90s × 3 attempts + sleeps + 30s fallback ≈ 300s\`
- Worst case total: \`4 papers × 300s = 1200s\`
- Vercel Pro default function limit: **60s** — function silently killed every time

## Solution

Three interlocking fixes that together bring each invocation to a ~191s worst case, well within a 300s ceiling.

### 1. Raise \`maxDuration\` to 300s (\`vercel.json\`)

Without this, Vercel Pro kills the function at 60s regardless of any timeout configuration inside the code. This is the critical infrastructure change.

\`maxDuration\` is set via the build entry's \`"config"\` key (the correct location for \`builds\`-based Vercel projects — the top-level \`"functions"\` block is mutually exclusive with \`"builds"\` and was causing deployment failures).

Also adds a second \`/api/deliver\` cron at 09:00 UTC alongside the existing 08:00 run. Each invocation now processes one paper — two runs per day deliver the two ideas configured by \`MAX_IDEAS_PER_DAY=2\`.

### 2. Process one paper per invocation with a tight timeout (\`api/deliver.py\`)

- Query \`LIMIT 1\` with \`fetchone()\` instead of batching \`max_ideas_per_day * 2\` papers in a loop
- Pass \`deliver_llm_timeout\` (50s) to \`synthesize_idea()\` instead of \`openrouter_timeout\` (90s)

\`openrouter_timeout\` is unchanged and continues to govern \`/spark\` and chat, which have a different time budget.

### 3. Owner notification on every cron outcome (\`api/deliver.py\`)

Adds \`_notify_owner()\`: a best-effort Telegram ping to all \`TELEGRAM_CHAT_IDS\` after each delivery run, reporting either the delivered idea ID or the skip reason. This is the first visibility into cron execution without requiring Vercel log access.

### 4. \`deliver_llm_timeout\` config field (\`lib/config.py\`, \`.env.example\`)

New \`DELIVER_LLM_TIMEOUT\` env var (default \`50\`) decoupled from \`OPENROUTER_TIMEOUT\` (default \`90\`). Documents both in \`.env.example\`.

## Files changed

| File | Change |
|---|---|
| \`vercel.json\` | \`maxDuration: 300\` via build \`config\`; second cron at 09:00 UTC |
| \`api/deliver.py\` | Single-paper-per-run refactor; \`deliver_llm_timeout\`; \`_notify_owner()\` |
| \`lib/config.py\` | \`deliver_llm_timeout\` field added |
| \`.env.example\` | Document \`DELIVER_LLM_TIMEOUT\` and \`OPENROUTER_TIMEOUT\` |
| \`tests/test_deliver.py\` | Updated mock helper and all call sites; replaced loop-based test with single-paper contract test; added \`TestRunDeliverTimeout\` and \`TestNotifyOwner\` |

## Deployment

No env changes required — \`DELIVER_LLM_TIMEOUT\` defaults to \`50s\`. \`CRON_SECRET\` is auto-generated and injected by Vercel Pro.

**Post-deploy verification:** \`GET /api/deliver\` with \`Authorization: Bearer <CRON_SECRET>\` should return \`{"sent": 1}\` and deliver an idea + status ping to Telegram.

Closes #1