### PR TITLE
fix(filter): parse pgvector string correctly when reading seed corpus

### DIFF
--- a/lib/filter.py
+++ b/lib/filter.py
@@ -2,6 +2,19 @@ from lib.embeddings import embed_text, cosine_similarity
 from lib.db import get_connection
 
 
+def _parse_vector(v) -> list[float]:
+    """Convert a pgvector value to a list of floats.
+
+    psycopg2 without a registered pgvector adapter returns vector columns as
+    the raw string "[0.1,0.2,...]". list() on a string yields characters, not
+    floats — this helper handles both the string case and the already-parsed
+    list/sequence case.
+    """
+    if isinstance(v, str):
+        return [float(x) for x in v.strip("[]").split(",")]
+    return list(v)
+
+
 class RelevanceFilter:
 
     def __init__(self, topics: list[str], threshold: float, database_url: str = None,
@@ -52,5 +65,5 @@ class RelevanceFilter:
             rows = cur.fetchall()
         conn.close()
 
-        self._seed_embeddings = [list(row["embedding"]) for row in rows if row["embedding"]]
+        self._seed_embeddings = [_parse_vector(row["embedding"]) for row in rows if row["embedding"]]
         return self._seed_embeddings

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -7,7 +7,7 @@ import pytest
 sys.modules.setdefault("psycopg2", MagicMock())
 sys.modules.setdefault("psycopg2.extras", MagicMock())
 
-from lib.filter import RelevanceFilter  # noqa: E402
+from lib.filter import RelevanceFilter, _parse_vector  # noqa: E402
 
 
 class TestRelevanceFilterInit:
@@ -295,3 +295,42 @@ class TestGetSeedEmbeddings:
         result = rf._get_seed_embeddings()
 
         assert len(result) == 2
+
+    @patch("lib.filter.get_connection")
+    def test_parses_string_vector_from_db(self, mock_get_conn):
+        # psycopg2 without a pgvector adapter returns vector columns as raw
+        # strings ("[0.1,0.2,...]"). Verify they are correctly parsed to floats.
+        vec = [0.1] * 4
+        string_repr = "[" + ",".join(str(x) for x in vec) + "]"
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [{"embedding": string_repr}]
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        rf = RelevanceFilter(topics=["momentum"], threshold=0.65, database_url="postgresql://localhost/test")
+        result = rf._get_seed_embeddings()
+
+        assert result == [pytest.approx(vec)]
+        assert all(isinstance(x, float) for x in result[0])
+
+
+class TestParseVector:
+
+    def test_parses_string_format(self):
+        assert _parse_vector("[0.1,0.2,0.3]") == pytest.approx([0.1, 0.2, 0.3])
+
+    def test_parses_list_passthrough(self):
+        v = [0.1, 0.2, 0.3]
+        assert _parse_vector(v) == pytest.approx(v)
+
+    def test_string_length_matches_dimension(self):
+        vec = [0.5] * 1536
+        s = "[" + ",".join(str(x) for x in vec) + "]"
+        result = _parse_vector(s)
+        assert len(result) == 1536
+
+    def test_string_values_are_floats(self):
+        result = _parse_vector("[1.0,2.0,3.0]")
+        assert all(isinstance(x, float) for x in result)


### PR DESCRIPTION
## Problem

`/api/fetch` was crashing with:

```
shapes (1536,) and (19187,) not aligned: 1536 (dim 0) != 19187 (dim 0)
```

This prevented any papers from being ingested, so `/api/deliver` always returned `{"sent": 0, "reason": "no papers or no active users"}`.

## Root cause

`lib/db.py` connects with plain `psycopg2` and no registered pgvector type adapter. Without the adapter, psycopg2 returns `vector` columns as raw strings in the format `"[0.1,0.2,...]"` rather than as a parsed list of floats.

In `lib/filter.py`, `_get_seed_embeddings()` did:

```python
self._seed_embeddings = [list(row["embedding"]) for row in rows if row["embedding"]]
```

`list()` on a string splits it into individual characters — e.g. `['[', '0', '.', '1', ',', ...]`. A 1536-dimensional vector stored as a string has ~19187 characters, so numpy's dot product failed with a dimension mismatch when trying to compute cosine similarity against the 1536-dim abstract embedding.

## Fix

Add a `_parse_vector()` helper in `lib/filter.py` that handles both the string case (returned by psycopg2 without the adapter) and the already-parsed list/sequence case:

```python
def _parse_vector(v) -> list[float]:
    if isinstance(v, str):
        return [float(x) for x in v.strip("[]").split(",")]
    return list(v)
```

Use it in `_get_seed_embeddings()` instead of `list()`.

## Files changed

| File | Change |
|---|---|
| `lib/filter.py` | Add `_parse_vector()` helper; use it in `_get_seed_embeddings()` |
| `tests/test_filter.py` | Add `TestParseVector` class and a string-format test in `TestGetSeedEmbeddings` |

## Verification

After merging, trigger `/api/fetch` manually — it should return `{"fetched": N, "stored": M, ...}` instead of a 500 error. Once papers are in the database, `/api/deliver` will send the first idea.