### PR TITLE
fix: add maxDuration for spark/fetch and widen arXiv window to 7 days

### DIFF
--- a/api/fetch.py
+++ b/api/fetch.py
@@ -49,6 +49,7 @@ def run_fetch(cfg) -> dict:
     arxiv_papers = fetch_recent_papers(
         categories=cfg.arxiv_categories,
         max_results=cfg.arxiv_max_results,
+        hours=168,
     )
     papers.extend(arxiv_papers)
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,9 @@
 {
   "builds": [
-    { "src": "api/fetch.py",    "use": "@vercel/python" },
+    { "src": "api/fetch.py",    "use": "@vercel/python", "config": { "maxDuration": 60 } },
     { "src": "api/deliver.py",  "use": "@vercel/python", "config": { "maxDuration": 300 } },
     { "src": "api/telegram.py", "use": "@vercel/python" },
-    { "src": "api/spark.py",    "use": "@vercel/python" },
+    { "src": "api/spark.py",    "use": "@vercel/python", "config": { "maxDuration": 60 } },
     { "src": "api/status.py",   "use": "@vercel/python" },
     { "src": "api/papers.py",  "use": "@vercel/python" },
     { "src": "api/chat.py",    "use": "@vercel/python" },


### PR DESCRIPTION
## Summary

- **`api/spark.py`** — added `"config": { "maxDuration": 60 }` in `vercel.json`. Vercel was killing this function at the 10-second default before OpenRouter LLM synthesis (~5-15s) completed, so `/spark` always showed "Searching for a paper…" and never delivered an idea.
- **`api/fetch.py`** — added `"config": { "maxDuration": 60 }` in `vercel.json` to guard against slow arXiv API responses, and added `hours=168` to `fetch_recent_papers()` to cover a 7-day window instead of 36 hours. arXiv publishes no new `q-fin.PM`/`q-fin.ST` papers on weekends, so the 36-hour window left the queue empty every Sunday/Monday, causing deliver to exit early with "no papers or no active users".

Note: `api/deliver.py` already has `maxDuration: 300` from PR #29 — no change there.

## Root Causes

| Bug | Root Cause | Fix |
|-----|-----------|-----|
| `/spark` shows "Searching…" but never delivers | `api/spark.py` missing `maxDuration` → Vercel kills at 10s during LLM call | `"config": { "maxDuration": 60 }` in `vercel.json` |
| Deliver skips on Mon/Tue: "no papers" | arXiv 36h window covers only weekend (no q-fin papers published); deliver finds empty queue | `hours=168` in `fetch_recent_papers()` call |

## Test Plan

- [ ] Deploy to Vercel and send `/spark` in Telegram — should receive a full idea within ~30-60s (not just "Searching…")
- [ ] Manually trigger `GET /api/fetch` then `GET /api/deliver` with the `CRON_SECRET` bearer token on a Monday — deliver should not exit early with "no papers"
- [ ] Check Vercel function logs for `/api/spark` — should show function completing with 200, not a timeout kill