### PR TITLE
fix: raise spark maxDuration to 300s and cap LLM timeout at 50s

### DIFF
--- a/api/spark.py
+++ b/api/spark.py
@@ -60,7 +60,7 @@ def run_spark(user_id: int, chat_id: int, conn, cfg) -> dict:
         model=cfg.default_model,
         api_key=cfg.openrouter_api_key,
         fallback_model=cfg.fallback_model,
-        timeout=cfg.openrouter_timeout,
+        timeout=cfg.deliver_llm_timeout,
     )
 
     if idea is None:

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
     { "src": "api/fetch.py",    "use": "@vercel/python", "config": { "maxDuration": 60 } },
     { "src": "api/deliver.py",  "use": "@vercel/python", "config": { "maxDuration": 300 } },
     { "src": "api/telegram.py", "use": "@vercel/python" },
-    { "src": "api/spark.py",    "use": "@vercel/python", "config": { "maxDuration": 60 } },
+    { "src": "api/spark.py",    "use": "@vercel/python", "config": { "maxDuration": 300 } },
     { "src": "api/status.py",   "use": "@vercel/python" },
     { "src": "api/papers.py",  "use": "@vercel/python" },
     { "src": "api/chat.py",    "use": "@vercel/python" },


### PR DESCRIPTION
## Summary

- **** —   raised from 60 → 300 to match .
- **** —  timeout changed from  (90s) to  (50s).

## Root Cause

PR #32 set  for , but  was called with . Vercel killed the function at 60s — mid-LLM-call — before any Telegram message (success or error) could be sent. The user saw only "Searching for a paper…" and nothing more. The `except Exception` handler in the spark endpoint never got to run.

 already handled this correctly:  + . Spark now uses the same pattern.

## Test Plan

- [ ] Deploy and send `/spark` — should receive a complete idea within ~30s
- [ ] If the LLM is slow, user should receive "The AI model is taking too long…" rather than silence
- [ ] Vercel function logs for `/api/spark` should show a 200 completion, not a timeout kill