### PR TITLE
feat: incorporate Semantic Scholar citation counts as a relevance signal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,10 @@ CHAT_MAX_MESSAGES_PER_HOUR=20
 CHAT_SESSION_TIMEOUT_HOURS=2
 CHAT_MAX_TOKENS_PER_USER_PER_DAY=50000
 
+# Semantic Scholar enrichment
+SEMANTIC_SCHOLAR_API_KEY=       # Optional: raises rate limit from 1 to 10 req/s
+CITATION_WEIGHT=0.02            # Log-scaled citation boost weight applied at paper selection (0 to disable)
+
 # GitHub issue integration
 GITHUB_TOKEN=                   # PyGithub PAT (repo scope)
 GITHUB_REPO_OWNER=              # your-username

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,31 +6,32 @@ Axiom is a serverless, event-driven pipeline designed for quantitative research 
 
 ```mermaid
 graph TD
-    A[arXiv API] -->|Daily Fetch| B(api/fetch)
+    A[arXiv API] -->|Daily Fetch - 7-day window| B(api/fetch)
+    SS[Semantic Scholar API] -->|Batch citation lookup| B
     B -->|Filter 1: Keywords| C{Relevance Filter}
     B -->|Filter 2: Embeddings| C
-    C -->|Store Relevant| D[(Neon Postgres)]
-    
-    E[cron-job.org] -->|Trigger| B
+    C -->|Store with citation_count| D[(Neon Postgres)]
+
+    E[Vercel Cron] -->|Trigger| B
     E -->|Trigger| F(api/deliver)
-    
-    F -->|Query Queued| D
+
+    F -->|Query by citation-boosted score| D
     D -->|Paper Abstract| G[OpenRouter LLM]
     G -->|Hypothesis + Method| H{Quality Gate}
     H -->|Pass| I[Telegram Delivery]
-    
+
     I -->|User Feedback| J(api/telegram)
     J -->|Update Weights| D
     J -->|Personalize| C
-    
+
     I -->|/chat Command| J
     J -->|Interactive Session| L[lib/chat]
     L -->|Contextual Prompt| G
-    
+
     I -->|/report Command| J
     J -->|Security Check| M[lib/security_validator]
     M -->|Create Issue| N[GitHub API]
-    
+
     I -->|/spark Command| J
     J -->|Trigger| K(api/spark)
     K -->|Query or Fetch| D
@@ -39,50 +40,65 @@ graph TD
 
 ## Core Components
 
-### 1. Ingestion & Filtering (`api/fetch`)
-- **arXiv Client**: Polls specific categories (e.g., `q-fin.PM`, `q-fin.ST`) for papers published in the last 36 hours.
-- **Two-Stage Filter**:
-    - **Keyword Matching**: Fast pre-filtering against a dynamic list of topics.
-    - **Vector Similarity**: Uses OpenRouter embeddings (`openai/text-embedding-3-small`) to compare paper abstracts against a "Seed Corpus" of high-quality reference papers stored in `pgvector`.
+### 1. Ingestion & Enrichment (`api/fetch`)
+- **arXiv Client**: Polls specific categories (e.g., `q-fin.PM`, `q-fin.ST`) for papers published in the last **7 days** (168-hour rolling window).
+- **Two-Stage Relevance Filter**:
+    - **Keyword Matching**: Fast pre-filtering against a dynamic list of topics from `ALLOWED_TOPICS`.
+    - **Vector Similarity**: Uses OpenRouter embeddings (`openai/text-embedding-3-small`, 1536 dimensions) to compare paper abstracts against a "Seed Corpus" of high-quality reference papers stored in `pgvector`.
+- **Citation Enrichment**: After inserting papers that pass the relevance threshold, Axiom calls the [Semantic Scholar Graph API](https://api.semanticscholar.org/graph/v1) in a single batch request to fetch citation counts. arXiv IDs are converted to the `ArXiv:YYMM.NNNNN` format (version suffix stripped). Results are stored in `papers.citation_count`. The step is fail-open — a Semantic Scholar outage does not block ingestion.
 - **Deduplication**: Ensures the same paper isn't processed twice across overlapping windows.
 
-### 2. Synthesis (`api/deliver`)
-- **LLM Orchestration**: Routes abstracts to OpenRouter (defaulting to Gemini 1.5 Flash for speed/cost, with Claude 3.5 Haiku for "Deep Dive" sessions).
+### 2. Ranking & Selection (`api/deliver`, `api/spark`)
+- **Citation-Boosted Score**: At selection time, papers are ranked by a composite score:
+  ```
+  effective_score = relevance_score + citation_weight × LN(GREATEST(COALESCE(citation_count, 0) + 1, 1))
+  ```
+  With the default `CITATION_WEIGHT=0.02`, this adds up to ~0.14 to a paper's score for 1 000+ citations, augmenting but never overriding semantic relevance. Papers with no citation data (`NULL`) are treated as zero-cited.
+
+### 3. Synthesis (`api/deliver`)
+- **LLM Orchestration**: Routes abstracts to OpenRouter (defaulting to `google/gemini-2.5-flash` for speed/cost, with `anthropic/claude-3-5-haiku` for "Deep Dive" sessions on Fridays).
 - **Structured Extraction**: The system prompt enforces a rigorous "Senior Quant" persona, focusing on methodology, data requirements, and feasibility.
-- **Scoring**: Every idea is assigned a **Novelty** and **Feasibility** score (1-10).
+- **Scoring**: Every idea is assigned a **Novelty** and **Feasibility** score (1–10).
 - **Quality Gate**: Only ideas exceeding a combined threshold (default: 13/20) are delivered.
 
-### 3. Delivery & Feedback (`api/telegram`)
+### 4. Delivery & Feedback (`api/telegram`)
 - **Interactive Interface**: Ideas are delivered via Telegram Bot API with inline buttons for feedback ("Interesting" vs. "Skip").
 - **Dynamic Weighting**:
     - "Interesting" (+1) increases the weight of matching keywords in the database.
-    - "Skip" (-1) decreases weights.
+    - "Skip" (−1) decreases weights.
 - **Personalization**: These weights are applied as multipliers during the next day's filtering stage, allowing Axiom to "learn" your research preferences over time.
-- **Command Handling**: Processes bot commands like `/spark` (which triggers `api/spark` for on-demand generation) and `/status`.
+- **Command Handling**: Processes bot commands including `/spark`, `/status`, `/topics`, `/feedback`, `/chat`, `/report`, `/pause`, and `/resume`.
+- **Rate Limiting**: `/spark` is rate-limited per user to prevent API abuse.
+- **Security**: Webhook payloads are verified using HMAC constant-time comparison. IP allowlisting (optional) further restricts requests to Telegram's known IP ranges.
 
-### 4. Data Layer (Neon Postgres)
-- **Relational Schema**: Manages papers, ideas, authorized users, feedback, and **conversation sessions**.
+### 5. Data Layer (Neon Postgres)
+- **Relational Schema**: Manages papers, ideas, authorized users, feedback, conversation sessions, and GitHub submissions.
 - **Vector Search**: Leverages `pgvector` for efficient cosine similarity searches in **1536-dimensional** space.
-- **Automated Migrations**: SQL-based schema management for easy deployment.
+- **Automated Migrations**: SQL-based schema management (`migrations/001` through `migrations/010`) for easy deployment.
 - **Topic Auto-Sync**: The database automatically stays in sync with your configured `ALLOWED_TOPICS` environment variable whenever fetch or spark endpoints are called.
+- **Citation Storage**: `papers.citation_count` (INT, nullable) holds the Semantic Scholar citation count. Existing papers without citation data are progressively backfilled on subsequent fetch runs.
 
-### 5. Research Chat (`lib/chat`)
+### 6. Research Chat (`lib/chat`)
 - **Session Management**: Tracks context across multiple messages per research idea.
 - **Contextual Retrieval**: Automatically injects paper abstracts and current idea details into the LLM context.
 - **Rate Limiting**: Multi-tier limits (per session, per hour, per day) to prevent API abuse.
 
-### 6. GitHub Issue Integration (`lib/github_client`)
+### 7. GitHub Issue Integration (`lib/github_client`)
 - **Security Validation**: A multi-layer pipeline (`lib/security_validator`) checks for profanity, PII, and injection attempts before submission.
 - **AI-Powered Triaging**: Uses LLMs to generate concise issue titles and format detailed markdown bodies with technical context.
 - **Traceability**: Submissions are linked to the specific research session and Telegram user for easy debugging.
 
-### 7. On-Demand Synthesis (`api/spark`)
+### 8. On-Demand Synthesis (`api/spark`)
 - **Instant Generation**: Triggered by the `/spark` Telegram command to instantly generate a new hypothesis outside the daily schedule.
-- **Fallback Search Strategy**: Searches sequentially for: unprocessed papers, processed but un-sparked papers, a fresh 7-day arXiv fetch, and finally previously skipped papers.
+- **Fallback Search Strategy**: Searches sequentially for:
+  1. Unprocessed papers in DB (citation-boosted ranking)
+  2. Processed but un-sparked papers (citation-boosted ranking)
+  3. A fresh 7-day arXiv fetch with keyword-only scoring
+  4. Previously skipped papers re-evaluated against current topics
 - **Auto-Syncing**: Guarantees the user's topics are synchronized to the database before processing.
-- **Resilience**: Retry logic with configurable fallback model (`FALLBACK_MODEL`) and tunable timeout (`OPENROUTER_TIMEOUT`).
+- **Resilience**: Retry logic with configurable fallback model (`FALLBACK_MODEL`) and tunable timeout (`OPENROUTER_TIMEOUT`). The endpoint has a 300-second Vercel `maxDuration` to accommodate slow LLM responses.
 
-### 8. Landing Page & Public API (`api/status`, `api/papers`, `api/chat`)
+### 9. Landing Page & Public API (`api/status`, `api/papers`, `api/chat`)
 - **Status Endpoint**: Returns live system health, total paper/idea counts, and last fetch/deliver timestamps.
 - **Papers Endpoint**: Returns the 20 most recent non-skipped papers (title, categories, arXiv URL, fetched timestamp). Unauthenticated, CORS-enabled.
 - **Chat Endpoint** (`api/chat`): Stateless `POST` endpoint that answers visitor questions about the codebase and architecture. Calls OpenRouter with an inlined system prompt; no auth, no DB, no additional dependencies.
@@ -91,4 +107,6 @@ graph TD
 ## Security & Reliability
 - **Webhook Secrets**: Verifies Telegram payloads using HMAC constant-time comparison.
 - **Cron Authentication**: API endpoints verify `CRON_SECRET` via `Authorization: Bearer` header (used by Vercel cron) or `?key=` query parameter (for manual invocation).
+- **IP Allowlisting**: Optional `TELEGRAM_IP_ALLOWLIST_ENABLED` flag restricts webhook requests to Telegram's published IP ranges.
+- **Fail-Open Design**: External enrichment steps (Semantic Scholar) and non-critical integrations never block the core ingestion or delivery pipeline.
 - **Serverless Resilience**: Distributed across Vercel's global edge network, minimizing latency and eliminating single points of failure.

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -104,9 +104,11 @@ vercel env add MAX_IDEAS_PER_DAY
 vercel env add GITHUB_TOKEN
 vercel env add GITHUB_REPO_OWNER
 vercel env add GITHUB_REPO_NAME
+vercel env add SEMANTIC_SCHOLAR_API_KEY
+vercel env add CITATION_WEIGHT
 ```
 
-Refer to `.env.example` for descriptions and sensible defaults for each variable.
+Refer to `.env.example` for descriptions and sensible defaults for each variable. `SEMANTIC_SCHOLAR_API_KEY` is optional — the Semantic Scholar API works without a key at 1 request/second. `CITATION_WEIGHT` defaults to `0.02` if omitted.
 
 4. Deploy:
 
@@ -183,10 +185,10 @@ curl -H "Authorization: Bearer YOUR_CRON_SECRET" "https://your-project.vercel.ap
 curl "https://your-project.vercel.app/api/fetch?key=YOUR_CRON_SECRET"
 ```
 
-Check that papers landed in the database:
+Check that papers landed in the database, including citation counts fetched from Semantic Scholar:
 
 ```sql
-SELECT id, title, relevance_score FROM papers ORDER BY fetched_at DESC LIMIT 5;
+SELECT id, title, relevance_score, citation_count FROM papers ORDER BY fetched_at DESC LIMIT 5;
 ```
 
 Trigger the deliver endpoint:
@@ -239,6 +241,8 @@ Change `DEFAULT_MODEL` and `DEEPDIVE_MODEL` to any model available on OpenRouter
 - `QUALITY_GATE_MIN` (default 13) — minimum combined novelty + feasibility score (out of 20)
 - `DEDUP_SIMILARITY_MAX` (default 0.80) — how similar a new idea can be to a previously sent one
 - `MAX_IDEAS_PER_DAY` (default 2) — cap on daily idea delivery
+- `CITATION_WEIGHT` (default 0.02) — weight of the log-scaled citation boost applied at paper selection; set to `0` to disable citation ranking entirely
+- `SEMANTIC_SCHOLAR_API_KEY` (optional) — Semantic Scholar API key; omit to use the shared anonymous rate limit (1 req/s), or provide a key for 10 req/s
 
 ### Monitoring
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@
 
 ---
 
-Axiom is a lightweight, zero-infrastructure pipeline designed for quantitative researchers and traders. It monitors high-frequency academic outputs (primarily arXiv), applies a two-stage relevance filter, and employs state-of-the-art LLMs to synthesize novel research ideas — all delivered daily to your Telegram.
+Axiom is a lightweight, zero-infrastructure pipeline designed for quantitative researchers and traders. It monitors high-frequency academic outputs (primarily arXiv), applies a two-stage relevance filter enriched with citation signals, and employs state-of-the-art LLMs to synthesize novel research ideas — all delivered daily to your Telegram.
 
 ## 🚀 Key Features
 
-- **Automated Ingestion**: Daily polling of `q-fin.PM`, `q-fin.ST`, and more.
-- **Intelligent Filtering**: Combines traditional keyword matching with semantic vector similarity (`pgvector` + `sentence-transformers`).
+- **Automated Ingestion**: Daily polling of `q-fin.PM`, `q-fin.ST`, and more arXiv categories over a rolling 7-day window.
+- **Intelligent Filtering**: Combines traditional keyword matching with semantic vector similarity (`pgvector` + OpenRouter embeddings at 1536 dimensions).
+- **Citation-Count Enrichment**: After ingestion, Axiom queries the [Semantic Scholar API](https://api.semanticscholar.org/) to attach citation counts to new papers. Highly-cited work receives a log-scaled ranking boost at delivery time (`relevance_score + citation_weight × ln(citations + 1)`), surfacing established results alongside emerging research.
 - **Research Synthesis**: Generates structured hypotheses, implementation methods, and data requirements using OpenRouter (Gemini/Claude).
 - **Interactive Feedback**: Personalize your research feed via simple "Interesting" or "Skip" buttons in Telegram.
 - **On-Demand Ideation**: Request a fresh hypothesis anytime via the `/spark` Telegram command.
@@ -32,7 +33,7 @@ Axiom is a lightweight, zero-infrastructure pipeline designed for quantitative r
 - **Issue Reporting**: Submit bug reports or feature requests directly from Telegram to GitHub via the `/report` command.
 - **Dynamic Learning**: The system automatically updates topic weights based on your feedback (auto-synced with your configured topics) to improve future signal quality.
 - **Recent Papers Feed**: Click the Papers count on the landing page to reveal an expandable drawer showing the 20 most recent papers with arXiv links, category badges, and relative timestamps.
-- **Zero-Cost Operation**: Fully utilizes free tiers of Vercel, Neon, OpenRouter, and cron-job.org (~$0.03/month for high-volume API usage).
+- **Zero-Cost Operation**: Fully utilizes free tiers of Vercel, Neon, OpenRouter, and cron-job.org. The Semantic Scholar API is also free for low-volume usage (~$0.03/month for high-volume API usage overall).
 
 ## 🛠 Tech Stack
 
@@ -41,18 +42,20 @@ Axiom is built for reliability and minimal maintenance.
 - **Language**: Python 3.11+
 - **Infrastructure**: Vercel Serverless Functions + Vercel Cron.
 - **Database**: Neon Postgres with `pgvector` for semantic search.
-- **Intelligence**: OpenRouter (Gemini 1.5 Flash for daily runs, Claude 3.5 Haiku for Friday deep-dives).
+- **Intelligence**: OpenRouter (Gemini 2.5 Flash for daily runs, Claude 3.5 Haiku for Friday deep-dives).
 - **Embeddings**: OpenRouter (`openai/text-embedding-3-small`) at 1536 dimensions for high-precision semantic matching.
+- **Citation Data**: [Semantic Scholar Graph API](https://api.semanticscholar.org/graph/v1) for paper citation counts.
 
 > **[Read more about the Tech Stack](TECH-STACK.md)**
 
 ## 📐 Architecture
 
-Axiom's architecture follows a classic event-driven pipeline: **Ingest → Filter → Synthesize → Deliver → Learn**.
+Axiom's architecture follows a classic event-driven pipeline: **Ingest → Enrich → Filter → Synthesize → Deliver → Learn**.
 
 ```mermaid
 graph LR
     arXiv(arXiv) --> Fetch(api/fetch)
+    SS(Semantic Scholar) --> Fetch
     Fetch --> DB[(Neon Postgres)]
     DB --> Deliver(api/deliver)
     Deliver --> LLM(OpenRouter)
@@ -81,7 +84,7 @@ Setting up your own instance of Axiom takes less than 15 minutes.
 
 ```text
 ├── api/             # Vercel Serverless Function entry points
-├── lib/             # Core business logic (arXiv, DB, LLM, Telegram)
+├── lib/             # Core business logic (arXiv, Semantic Scholar, DB, LLM, Telegram)
 ├── migrations/      # SQL schema management
 ├── prompts/         # Structured LLM templates (System, Extraction, Ideation)
 ├── public/          # Landing page (HTML, CSS, JS)

--- a/TECH-STACK.md
+++ b/TECH-STACK.md
@@ -4,32 +4,47 @@ The following technologies power the Axiom pipeline, chosen for their zero-cost 
 
 ## Core Language & Runtime
 
-- **Python 3.11+**: The core logic is built with modern, asynchronous-ready Python.
-- **Vercel Serverless Functions**: Provides a serverless execution environment with zero infrastructure management.
-- **Vercel Cron**: Scheduled triggers for daily ingestion and delivery.
+- **Python 3.11+**: The core logic is built with modern, type-annotated Python.
+- **Vercel Serverless Functions**: Provides a serverless execution environment with zero infrastructure management. Key endpoints (`api/fetch`, `api/spark`) use a 300-second `maxDuration` to accommodate long-running LLM calls.
+- **Vercel Cron**: Scheduled triggers for daily ingestion (06:00 UTC) and delivery (08:00 UTC).
 
 ## Data & Vectors
 
 - **Neon Postgres**: A serverless PostgreSQL database that scales to zero when not in use.
-- **pgvector**: Enables vector similarity search within Postgres, allowing for semantic filtering of research abstracts.
-- **Sentence-Transformers**: Uses the `all-MiniLM-L6-v2` model to generate 384-dimensional embeddings for research abstracts.
+- **pgvector**: Enables vector similarity search within Postgres, allowing for semantic filtering of research abstracts at **1536 dimensions**.
+- **OpenRouter Embeddings**: Uses `openai/text-embedding-3-small` via OpenRouter to generate 1536-dimensional embeddings for research abstracts and idea deduplication.
 
 ## Intelligence Layer
 
 - **OpenRouter**: Unified API access to state-of-the-art LLMs, primarily:
-    - **Google Gemini 1.5 Flash**: Efficient, high-throughput daily processing.
-    - **Anthropic Claude 3.5 Haiku**: Deep-dive synthesis and higher-quality ideation.
+    - **Google Gemini 2.5 Flash** (`google/gemini-2.5-flash`): Efficient, high-throughput daily processing and on-demand synthesis.
+    - **Anthropic Claude 3.5 Haiku** (`anthropic/claude-3-5-haiku-20241022`): Deep-dive synthesis on Fridays for higher-quality ideation.
+    - **Google Gemini Flash 1.5** (`google/gemini-flash-1.5`): Powers the interactive `/chat` sessions and the public "Ask Axiom" chatbot widget.
+- **Fallback Routing**: Automatic retry with a configurable `FALLBACK_MODEL` (default: `google/gemini-2.0-flash`) on LLM timeouts.
+
+## External Data Sources
+
+- **arXiv API**: Polls quantitative finance and machine learning categories over a rolling 7-day window. Papers are filtered by keyword and semantic similarity before storage.
+- **Semantic Scholar Graph API**: After arXiv ingestion, Axiom calls the [Semantic Scholar batch endpoint](https://api.semanticscholar.org/graph/v1/paper/batch) to retrieve citation counts for newly stored papers. These counts are stored in `papers.citation_count` and applied as a log-scaled ranking boost at delivery time. The API is free for low-volume usage; an optional `SEMANTIC_SCHOLAR_API_KEY` raises the rate limit from 1 to 10 requests/second.
 
 ## Communication & Delivery
 
-- **Telegram Bot API**: Delivers real-time research alerts and collects interactive user feedback.
-- **Httpx**: Modern, fully-featured HTTP client for all API interactions (arXiv, Telegram, OpenRouter).
+- **Telegram Bot API**: Delivers real-time research alerts with inline feedback buttons, and handles commands including `/spark`, `/chat`, `/report`, `/pause`, `/resume`, `/status`, `/topics`, and `/feedback`.
+- **GitHub REST API** (via PyGithub): Creates structured, AI-triaged issues from `/report` submissions, with security validation applied before any GitHub call.
+- **Httpx**: Modern, fully-featured HTTP client for all outbound API interactions (arXiv, Semantic Scholar, Telegram, OpenRouter).
+
+## Security
+
+- **HMAC Webhook Verification**: Telegram webhook payloads are verified using constant-time HMAC comparison (`lib/security_validator`).
+- **Multi-Layer Input Validation**: `/report` submissions pass through profanity, PII, and injection-detection checks before reaching the GitHub API.
+- **Rate Limiting**: `/spark` is rate-limited per user. The `/chat` endpoint enforces per-session, per-hour, and per-day token limits.
+- **IP Allowlisting**: Optional `TELEGRAM_IP_ALLOWLIST_ENABLED` restricts webhook ingress to Telegram's published IP ranges.
 
 ## Quality Assurance
 
-- **Pytest**: Comprehensive unit and integration testing suite.
-- **Pytest-Httpx**: For mocking external API calls during testing.
-- **Pydantic**: Robust data validation and settings management.
+- **Pytest**: Comprehensive unit test suite covering all core modules and API handlers.
+- **Pytest-Httpx**: For mocking external HTTP calls during testing.
+- **Pydantic**: Robust data validation at system boundaries.
 
 ## Support Libraries
 

--- a/api/deliver.py
+++ b/api/deliver.py
@@ -51,13 +51,16 @@ def run_deliver(cfg) -> dict:
     conn = get_connection(cfg.database_url)
     try:
         with conn.cursor() as cur:
-            # Fetch the single highest-scored unprocessed paper
+            # Fetch the single highest-scored unprocessed paper (citation-boosted)
             cur.execute(
                 """SELECT id, title, abstract, url
                    FROM papers
                    WHERE NOT processed AND NOT skipped
-                   ORDER BY relevance_score DESC
+                   ORDER BY (
+                     relevance_score + %s * LN(GREATEST(COALESCE(citation_count, 0) + 1, 1))
+                   ) DESC
                    LIMIT 1""",
+                (cfg.citation_weight,),
             )
             paper = cur.fetchone()
 

--- a/api/fetch.py
+++ b/api/fetch.py
@@ -6,6 +6,7 @@ from lib.arxiv import fetch_recent_papers
 from lib.rss import fetch_rss_papers
 from lib.filter import RelevanceFilter
 from lib.db import get_connection
+from lib.semantic_scholar import fetch_citation_counts
 from scripts.sync_topics import sync_topic_weights
 
 
@@ -88,6 +89,7 @@ def run_fetch(cfg) -> dict:
     # Ensure all topics from ALLOWED_TOPICS exist in topic_weights
     sync_topic_weights(conn, cfg.allowed_topics)
 
+    newly_stored_ids = []
     with conn.cursor() as cur:
         for paper in papers:
             # Skip if already in DB
@@ -120,15 +122,34 @@ def run_fetch(cfg) -> dict:
                      score, keyword_hits),
                 )
                 stored += 1
+                newly_stored_ids.append(paper.id)
 
             # Commit each paper individually to prevent rollback on timeout
             conn.commit()
+
+    # Batch-enrich newly stored papers with citation counts from Semantic Scholar
+    citation_counts_fetched = 0
+    if newly_stored_ids:
+        citation_counts = fetch_citation_counts(
+            newly_stored_ids,
+            api_key=cfg.semantic_scholar_api_key,
+        )
+        if citation_counts:
+            with conn.cursor() as cur:
+                for paper_id, count in citation_counts.items():
+                    cur.execute(
+                        "UPDATE papers SET citation_count = %s WHERE id = %s",
+                        (count, paper_id),
+                    )
+                conn.commit()
+            citation_counts_fetched = len(citation_counts)
 
     conn.close()
     return {
         "fetched": len(papers),
         "stored": stored,
         "skipped": skipped,
+        "citation_counts_fetched": citation_counts_fetched,
         "details": {
             "skipped": skipped_details
         }

--- a/api/spark.py
+++ b/api/spark.py
@@ -106,20 +106,23 @@ def run_spark(user_id: int, chat_id: int, conn, cfg) -> dict:
 
 
 def _find_paper_for_spark(conn, cfg) -> dict | None:
-    # Tier 1: Unprocessed papers in DB
+    # Tier 1: Unprocessed papers in DB (citation-boosted)
     with conn.cursor() as cur:
         cur.execute(
             """SELECT id, title, abstract, url
                FROM papers
                WHERE NOT processed AND NOT skipped
-               ORDER BY relevance_score DESC
-               LIMIT 1"""
+               ORDER BY (
+                 relevance_score + %s * LN(GREATEST(COALESCE(citation_count, 0) + 1, 1))
+               ) DESC
+               LIMIT 1""",
+            (cfg.citation_weight,),
         )
         paper = cur.fetchone()
     if paper:
         return paper
 
-    # Tier 1.5: Papers processed by deliver but not yet sparked on-demand
+    # Tier 1.5: Papers processed by deliver but not yet sparked on-demand (citation-boosted)
     with conn.cursor() as cur:
         cur.execute(
             """SELECT p.id, p.title, p.abstract, p.url
@@ -129,8 +132,11 @@ def _find_paper_for_spark(conn, cfg) -> dict | None:
                    SELECT 1 FROM ideas i
                    WHERE i.paper_id = p.id AND i.on_demand_by IS NOT NULL
                  )
-               ORDER BY p.relevance_score DESC
-               LIMIT 1"""
+               ORDER BY (
+                 p.relevance_score + %s * LN(GREATEST(COALESCE(p.citation_count, 0) + 1, 1))
+               ) DESC
+               LIMIT 1""",
+            (cfg.citation_weight,),
         )
         paper = cur.fetchone()
     if paper:

--- a/lib/config.py
+++ b/lib/config.py
@@ -46,6 +46,10 @@ class Config:
     # Security settings
     telegram_ip_allowlist_enabled: bool
 
+    # Semantic Scholar enrichment
+    semantic_scholar_api_key: str
+    citation_weight: float
+
 
 def load_config() -> Config:
     def require(key: str) -> str:
@@ -96,4 +100,8 @@ def load_config() -> Config:
 
         # Security settings
         telegram_ip_allowlist_enabled=os.getenv("TELEGRAM_IP_ALLOWLIST_ENABLED", "false").lower() == "true",
+
+        # Semantic Scholar enrichment
+        semantic_scholar_api_key=os.getenv("SEMANTIC_SCHOLAR_API_KEY", ""),
+        citation_weight=float(os.getenv("CITATION_WEIGHT", "0.02")),
     )

--- a/lib/semantic_scholar.py
+++ b/lib/semantic_scholar.py
@@ -1,0 +1,57 @@
+import httpx
+
+BATCH_URL = "https://api.semanticscholar.org/graph/v1/paper/batch"
+
+
+def _arxiv_id_to_ss_id(arxiv_id: str) -> str:
+    """Convert a DB paper ID (e.g. '2406.12345v1') to Semantic Scholar format ('ArXiv:2406.12345')."""
+    base = arxiv_id.split("v")[0] if "v" in arxiv_id else arxiv_id
+    return f"ArXiv:{base.replace('_', '/')}"
+
+
+def fetch_citation_counts(
+    arxiv_ids: list[str],
+    api_key: str = None,
+    timeout: int = 15,
+) -> dict[str, int]:
+    """Fetch citation counts from Semantic Scholar for a batch of arXiv paper IDs.
+
+    Returns a dict mapping arxiv_id -> citation_count.
+    Returns {} on any error so callers never need to handle exceptions (fail-open).
+    """
+    if not arxiv_ids:
+        return {}
+
+    ss_ids = [_arxiv_id_to_ss_id(aid) for aid in arxiv_ids]
+    id_map = dict(zip(ss_ids, arxiv_ids))
+
+    headers = {}
+    if api_key:
+        headers["x-api-key"] = api_key
+
+    try:
+        resp = httpx.post(
+            BATCH_URL,
+            json={"ids": ss_ids},
+            params={"fields": "citationCount"},
+            headers=headers,
+            timeout=timeout,
+        )
+        if resp.status_code == 429:
+            print("[semantic_scholar] rate limited, skipping citation enrichment")
+            return {}
+        if resp.status_code != 200:
+            print(f"[semantic_scholar] API error {resp.status_code}, skipping")
+            return {}
+
+        results = {}
+        for ss_id, item in zip(ss_ids, resp.json()):
+            if item is None:
+                continue
+            citation_count = item.get("citationCount")
+            if citation_count is not None:
+                results[id_map[ss_id]] = citation_count
+        return results
+    except Exception as e:
+        print(f"[semantic_scholar] fetch failed: {e}")
+        return {}

--- a/lib/semantic_scholar.py
+++ b/lib/semantic_scholar.py
@@ -1,3 +1,4 @@
+import re
 import httpx
 
 BATCH_URL = "https://api.semanticscholar.org/graph/v1/paper/batch"
@@ -5,7 +6,7 @@ BATCH_URL = "https://api.semanticscholar.org/graph/v1/paper/batch"
 
 def _arxiv_id_to_ss_id(arxiv_id: str) -> str:
     """Convert a DB paper ID (e.g. '2406.12345v1') to Semantic Scholar format ('ArXiv:2406.12345')."""
-    base = arxiv_id.split("v")[0] if "v" in arxiv_id else arxiv_id
+    base = re.sub(r'v\d+$', '', arxiv_id)
     return f"ArXiv:{base.replace('_', '/')}"
 
 

--- a/migrations/010_add_citation_count.sql
+++ b/migrations/010_add_citation_count.sql
@@ -1,0 +1,1 @@
+ALTER TABLE papers ADD COLUMN IF NOT EXISTS citation_count INT;

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -355,10 +355,11 @@ class TestRunFetchBelowThreshold:
 
 class TestRunFetchAboveThreshold:
 
+    @patch("api.fetch.fetch_citation_counts", return_value={})
     @patch("api.fetch.get_connection")
     @patch("api.fetch.RelevanceFilter")
     @patch("api.fetch.fetch_recent_papers")
-    def test_high_score_stored_normally(self, mock_fetch, mock_filter_cls, mock_conn):
+    def test_high_score_stored_normally(self, mock_fetch, mock_filter_cls, mock_conn, _mock_cit):
         mock_fetch.return_value = [_sample_paper()]
 
         mock_filter = MagicMock()
@@ -380,10 +381,11 @@ class TestRunFetchAboveThreshold:
 
 class TestRunFetchConnection:
 
+    @patch("api.fetch.fetch_citation_counts", return_value={})
     @patch("api.fetch.get_connection")
     @patch("api.fetch.RelevanceFilter")
     @patch("api.fetch.fetch_recent_papers")
-    def test_connection_committed_and_closed(self, mock_fetch, mock_filter_cls, mock_conn):
+    def test_connection_committed_and_closed(self, mock_fetch, mock_filter_cls, mock_conn, _mock_cit):
         mock_fetch.return_value = [_sample_paper()]
 
         mock_filter = MagicMock()
@@ -403,10 +405,11 @@ class TestRunFetchConnection:
         mock_conn_obj.commit.assert_called_once()
         mock_conn_obj.close.assert_called_once()
 
+    @patch("api.fetch.fetch_citation_counts", return_value={})
     @patch("api.fetch.get_connection")
     @patch("api.fetch.RelevanceFilter")
     @patch("api.fetch.fetch_recent_papers")
-    def test_uses_config_database_url(self, mock_fetch, mock_filter_cls, mock_conn):
+    def test_uses_config_database_url(self, mock_fetch, mock_filter_cls, mock_conn, _mock_cit):
         mock_fetch.return_value = [_sample_paper()]
 
         mock_filter = MagicMock()
@@ -428,10 +431,11 @@ class TestRunFetchConnection:
 
 class TestRunFetchFilterInit:
 
+    @patch("api.fetch.fetch_citation_counts", return_value={})
     @patch("api.fetch.get_connection")
     @patch("api.fetch.RelevanceFilter")
     @patch("api.fetch.fetch_recent_papers")
-    def test_filter_initialized_with_config(self, mock_fetch, mock_filter_cls, mock_conn):
+    def test_filter_initialized_with_config(self, mock_fetch, mock_filter_cls, mock_conn, _mock_cit):
         mock_fetch.return_value = [_sample_paper()]
 
         mock_filter = MagicMock()
@@ -465,10 +469,11 @@ class TestRunFetchFilterInit:
 
 class TestRunFetchFetchedCount:
 
+    @patch("api.fetch.fetch_citation_counts", return_value={})
     @patch("api.fetch.get_connection")
     @patch("api.fetch.RelevanceFilter")
     @patch("api.fetch.fetch_recent_papers")
-    def test_fetched_count_matches_total_papers(self, mock_fetch, mock_filter_cls, mock_conn):
+    def test_fetched_count_matches_total_papers(self, mock_fetch, mock_filter_cls, mock_conn, _mock_cit):
         papers = [_sample_paper(id=f"2401.{i:05d}") for i in range(5)]
         mock_fetch.return_value = papers
 

--- a/tests/test_semantic_scholar.py
+++ b/tests/test_semantic_scholar.py
@@ -1,0 +1,135 @@
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from lib.semantic_scholar import _arxiv_id_to_ss_id, fetch_citation_counts
+
+
+class TestArxivIdToSsId:
+
+    def test_strips_version_suffix(self):
+        assert _arxiv_id_to_ss_id("2406.12345v1") == "ArXiv:2406.12345"
+
+    def test_strips_higher_version(self):
+        assert _arxiv_id_to_ss_id("2406.12345v3") == "ArXiv:2406.12345"
+
+    def test_no_version_suffix(self):
+        assert _arxiv_id_to_ss_id("2406.12345") == "ArXiv:2406.12345"
+
+    def test_old_format_with_underscores(self):
+        # Old arXiv IDs stored as hep-ph_9905221 → ArXiv:hep-ph/9905221
+        assert _arxiv_id_to_ss_id("hep-ph_9905221") == "ArXiv:hep-ph/9905221"
+
+    def test_old_format_with_version(self):
+        assert _arxiv_id_to_ss_id("hep-ph_9905221v2") == "ArXiv:hep-ph/9905221"
+
+
+class TestFetchCitationCounts:
+
+    def test_empty_list_returns_empty_dict(self):
+        result = fetch_citation_counts([])
+        assert result == {}
+
+    @patch("lib.semantic_scholar.httpx.post")
+    def test_returns_correct_mapping(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [
+            {"citationCount": 42},
+            {"citationCount": 7},
+        ]
+        mock_post.return_value = mock_resp
+
+        result = fetch_citation_counts(["2406.00001v1", "2406.00002v1"])
+
+        assert result == {"2406.00001v1": 42, "2406.00002v1": 7}
+
+    @patch("lib.semantic_scholar.httpx.post")
+    def test_skips_null_entries(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [
+            None,
+            {"citationCount": 10},
+        ]
+        mock_post.return_value = mock_resp
+
+        result = fetch_citation_counts(["2406.00001v1", "2406.00002v1"])
+
+        assert result == {"2406.00002v1": 10}
+        assert "2406.00001v1" not in result
+
+    @patch("lib.semantic_scholar.httpx.post")
+    def test_skips_entries_without_citation_count(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [{"paperId": "abc"}]
+        mock_post.return_value = mock_resp
+
+        result = fetch_citation_counts(["2406.00001v1"])
+
+        assert result == {}
+
+    @patch("lib.semantic_scholar.httpx.post")
+    def test_returns_empty_on_429(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 429
+        mock_post.return_value = mock_resp
+
+        result = fetch_citation_counts(["2406.00001v1"])
+
+        assert result == {}
+
+    @patch("lib.semantic_scholar.httpx.post")
+    def test_returns_empty_on_http_error(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_post.return_value = mock_resp
+
+        result = fetch_citation_counts(["2406.00001v1"])
+
+        assert result == {}
+
+    @patch("lib.semantic_scholar.httpx.post")
+    def test_returns_empty_on_network_exception(self, mock_post):
+        mock_post.side_effect = Exception("connection refused")
+
+        result = fetch_citation_counts(["2406.00001v1"])
+
+        assert result == {}
+
+    @patch("lib.semantic_scholar.httpx.post")
+    def test_includes_api_key_header_when_provided(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [{"citationCount": 5}]
+        mock_post.return_value = mock_resp
+
+        fetch_citation_counts(["2406.00001v1"], api_key="mykey")
+
+        _, kwargs = mock_post.call_args
+        assert kwargs["headers"].get("x-api-key") == "mykey"
+
+    @patch("lib.semantic_scholar.httpx.post")
+    def test_omits_api_key_header_when_not_provided(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [{"citationCount": 5}]
+        mock_post.return_value = mock_resp
+
+        fetch_citation_counts(["2406.00001v1"])
+
+        _, kwargs = mock_post.call_args
+        assert "x-api-key" not in kwargs["headers"]
+
+    @patch("lib.semantic_scholar.httpx.post")
+    def test_sends_correct_ss_ids(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [{"citationCount": 0}]
+        mock_post.return_value = mock_resp
+
+        fetch_citation_counts(["2406.12345v2"])
+
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"] == {"ids": ["ArXiv:2406.12345"]}


### PR DESCRIPTION
Adds a batch enrichment step to the fetch pipeline that queries the Semantic Scholar API for citation counts after papers are stored. At selection time, deliver and spark apply a log-scaled citation boost (relevance_score + citation_weight * LN(citations + 1)) so highly-cited papers rank higher without overriding semantic relevance.

- lib/semantic_scholar.py: fail-open batch client; strips version suffix from arXiv IDs before lookup
- migrations/010_add_citation_count.sql: adds citation_count INT column
- api/fetch.py: batch-enriches newly stored papers post-insert
- api/deliver.py, api/spark.py: citation-boosted ORDER BY in paper selection
- lib/config.py: SEMANTIC_SCHOLAR_API_KEY and CITATION_WEIGHT (default 0.02)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Papers are now ranked by a combination of relevance score and citation count, with a configurable weighting adjustment.
  * Integrated automatic citation count enrichment from Semantic Scholar.
  * Added optional API key configuration to enable higher request rate limits for citation data fetching.
  * Citation weighting can be disabled by setting the modifier to `0` if preferred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->