### PR TITLE
fix(spark): isolate tier DB errors and fix pre-existing test gaps from citation-count PR

### DIFF
--- a/api/spark.py
+++ b/api/spark.py
@@ -1,6 +1,8 @@
 import json
 from http.server import BaseHTTPRequestHandler
 
+import psycopg2
+
 from lib.config import load_config
 from lib.db import get_connection
 from lib.openrouter import synthesize_idea
@@ -127,7 +129,7 @@ def _find_paper_for_spark(conn, cfg) -> dict | None:
             paper = cur.fetchone()
         if paper:
             return paper
-    except Exception as e:
+    except psycopg2.DatabaseError as e:
         conn.rollback()
         print(f"[spark] Tier 1 DB error, falling through: {e}")
 
@@ -152,7 +154,7 @@ def _find_paper_for_spark(conn, cfg) -> dict | None:
             paper = cur.fetchone()
         if paper:
             return paper
-    except Exception as e:
+    except psycopg2.DatabaseError as e:
         conn.rollback()
         print(f"[spark] Tier 1.5 DB error, falling through: {e}")
 

--- a/api/spark.py
+++ b/api/spark.py
@@ -111,42 +111,53 @@ def run_spark(user_id: int, chat_id: int, conn, cfg) -> dict:
 
 def _find_paper_for_spark(conn, cfg) -> dict | None:
     # Tier 1: Unprocessed papers in DB (citation-boosted)
-    with conn.cursor() as cur:
-        cur.execute(
-            """SELECT id, title, abstract, url
-               FROM papers
-               WHERE NOT processed AND NOT skipped
-               ORDER BY (
-                 relevance_score + %s * LN(GREATEST(COALESCE(citation_count, 0) + 1, 1))
-               ) DESC
-               LIMIT 1""",
-            (cfg.citation_weight,),
-        )
-        paper = cur.fetchone()
-    if paper:
-        return paper
+    print("[spark] Tier 1: querying DB for unprocessed papers")
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """SELECT id, title, abstract, url
+                   FROM papers
+                   WHERE NOT processed AND NOT skipped
+                   ORDER BY (
+                     relevance_score + %s * LN(GREATEST(COALESCE(citation_count, 0) + 1, 1))
+                   ) DESC
+                   LIMIT 1""",
+                (cfg.citation_weight,),
+            )
+            paper = cur.fetchone()
+        if paper:
+            return paper
+    except Exception as e:
+        conn.rollback()
+        print(f"[spark] Tier 1 DB error, falling through: {e}")
 
     # Tier 1.5: Papers processed by deliver but not yet sparked on-demand (citation-boosted)
-    with conn.cursor() as cur:
-        cur.execute(
-            """SELECT p.id, p.title, p.abstract, p.url
-               FROM papers p
-               WHERE p.processed = TRUE AND p.skipped = FALSE
-                 AND NOT EXISTS (
-                   SELECT 1 FROM ideas i
-                   WHERE i.paper_id = p.id AND i.on_demand_by IS NOT NULL
-                 )
-               ORDER BY (
-                 p.relevance_score + %s * LN(GREATEST(COALESCE(p.citation_count, 0) + 1, 1))
-               ) DESC
-               LIMIT 1""",
-            (cfg.citation_weight,),
-        )
-        paper = cur.fetchone()
-    if paper:
-        return paper
+    print("[spark] Tier 1.5: querying DB for processed-but-not-on-demand papers")
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """SELECT p.id, p.title, p.abstract, p.url
+                   FROM papers p
+                   WHERE p.processed = TRUE AND p.skipped = FALSE
+                     AND NOT EXISTS (
+                       SELECT 1 FROM ideas i
+                       WHERE i.paper_id = p.id AND i.on_demand_by IS NOT NULL
+                     )
+                   ORDER BY (
+                     p.relevance_score + %s * LN(GREATEST(COALESCE(p.citation_count, 0) + 1, 1))
+                   ) DESC
+                   LIMIT 1""",
+                (cfg.citation_weight,),
+            )
+            paper = cur.fetchone()
+        if paper:
+            return paper
+    except Exception as e:
+        conn.rollback()
+        print(f"[spark] Tier 1.5 DB error, falling through: {e}")
 
     # Tier 2: Expanded arXiv fetch (7-day window)
+    print("[spark] Tier 2: fetching fresh arXiv papers (7-day window)")
     arxiv_papers = fetch_recent_papers(
         categories=cfg.arxiv_categories,
         max_results=cfg.arxiv_max_results,
@@ -217,6 +228,7 @@ def _find_paper_for_spark(conn, cfg) -> dict | None:
             }
 
     # Tier 3: Re-evaluate skipped papers in DB against current topics
+    print("[spark] Tier 3: re-evaluating skipped papers")
     with conn.cursor() as cur:
         cur.execute(
             """SELECT id, title, abstract, url

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -23,6 +23,7 @@ def _make_config(**overrides):
         "database_url": "postgresql://localhost/test",
         "openrouter_api_key": "key",
         "default_model": "m",
+        "fallback_model": "m-fallback",
         "deepdive_model": "m2",
         "deepdive_day": 4,
         "cron_secret": "cron",
@@ -30,6 +31,8 @@ def _make_config(**overrides):
         "arxiv_max_results": 50,
         "allowed_topics": ["momentum"],
         "relevance_threshold": 0.65,
+        "quality_gate_min": 11,
+        "citation_weight": 0.02,
         "embedding_model": "openai/text-embedding-3-small",
     }
     defaults.update(overrides)
@@ -190,7 +193,7 @@ class TestFindPaperForSpark:
         mock_cursor.fetchone.return_value = None
         # Tier 3: top papers
         mock_cursor.fetchall.return_value = [
-            {"id": "2305_99999", "title": "T", "abstract": "A", "url": "u"},
+            {"id": "2305_99999", "title": "T", "abstract": "momentum strategy paper", "url": "u"},
         ]
         mock_conn = MagicMock()
         mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)


### PR DESCRIPTION
- Wrap Tier 1 and Tier 1.5 queries in _find_paper_for_spark() with individual try/except blocks so a missing citation_count column (or any other DB schema error) logs the failure and falls through to the next tier instead of propagating to the generic handler and sending "Something went wrong" to the user.
- Add [spark] Tier N: log lines at the start of each tier so Vercel traces pinpoint exactly where failures occur.
- Fix three pre-existing test_spark.py failures introduced by PR #35: add quality_gate_min, citation_weight, and fallback_model to _make_config(); fix Tier 3 test abstract to contain a keyword that passes the relevance filter.

Root cause of the live outage: migration 010 (citation_count column) was not applied to the production DB after PR #35 shipped. Apply:
  ALTER TABLE papers ADD COLUMN IF NOT EXISTS citation_count INT;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved resilience in database candidate selection with automatic fallback to subsequent processing tiers when errors occur
  * Added diagnostic logging for tier progression tracking

* **Tests**
  * Updated test configurations and fixtures for enhanced consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->