### PR TITLE
fix(deliver): split ambiguous skip reason into no_papers / no_active_users

### DIFF
--- a/api/deliver.py
+++ b/api/deliver.py
@@ -95,17 +95,22 @@ def run_deliver(cfg) -> dict:
         print(f"[deliver] candidate paper: {paper['id'] if paper else None}, "
               f"{len(active_users)} active users")
 
-        if not paper or not active_users:
-            reason = "no papers or no active users"
-            print(f"[deliver] early exit: {reason}")
-            _notify_owner(cfg, status="skipped", reason=reason)
+        if not paper:
+            print("[deliver] early exit: no unprocessed papers available")
+            _notify_owner(cfg, status="skipped", reason="no_papers")
             return {
                 "sent": 0,
-                "reason": reason,
-                "stats": {
-                    "papers_found": 1 if paper else 0,
-                    "active_users": len(active_users),
-                }
+                "reason": "no_papers",
+                "stats": {"papers_found": 0, "active_users": len(active_users)},
+            }
+
+        if not active_users:
+            print("[deliver] early exit: no active users")
+            _notify_owner(cfg, status="skipped", reason="no_active_users")
+            return {
+                "sent": 0,
+                "reason": "no_active_users",
+                "stats": {"papers_found": 1, "active_users": 0},
             }
 
         # Select model (deep-dive on configured day)
@@ -209,6 +214,16 @@ def _notify_owner(cfg, status: str, **details) -> None:
         text = (
             f"[Axiom] Delivered idea #{details.get('idea_id', '?')} at {ts}.\n"
             f"Paper: {details.get('paper_id', '?')} | Model: {details.get('model', '?')}"
+        )
+    elif details.get('reason') == "no_papers":
+        text = (
+            f"[Axiom] Delivery skipped at {ts}.\n"
+            f"No unprocessed papers in pipeline. Check /api/status for pipeline state."
+        )
+    elif details.get('reason') == "no_active_users":
+        text = (
+            f"[Axiom] Delivery skipped at {ts}.\n"
+            f"No active users. Send /start to the bot to subscribe."
         )
     else:
         text = (

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -246,6 +246,7 @@ class TestRunDeliverEarlyExit:
         cfg = _make_config()
         result = run_deliver(cfg)
         assert result["sent"] == 0
+        assert result["reason"] == "no_papers"
         assert "stats" in result
         assert result["stats"]["papers_found"] == 0
         mock_conn.close.assert_called_once()
@@ -257,6 +258,7 @@ class TestRunDeliverEarlyExit:
         cfg = _make_config()
         result = run_deliver(cfg)
         assert result["sent"] == 0
+        assert result["reason"] == "no_active_users"
         mock_conn.close.assert_called_once()
 
 
@@ -487,6 +489,20 @@ class TestNotifyOwner:
         _notify_owner(cfg, status="skipped", reason="below_quality_gate", paper_id="p1")
         text = mock_send.call_args[0][1]
         assert "below_quality_gate" in text
+
+    @patch("api.deliver.send_message")
+    def test_no_papers_message_mentions_pipeline(self, mock_send):
+        cfg = _make_config(telegram_chat_ids=[1])
+        _notify_owner(cfg, status="skipped", reason="no_papers")
+        text = mock_send.call_args[0][1]
+        assert "No unprocessed papers" in text
+
+    @patch("api.deliver.send_message")
+    def test_no_active_users_message_mentions_start(self, mock_send):
+        cfg = _make_config(telegram_chat_ids=[1])
+        _notify_owner(cfg, status="skipped", reason="no_active_users")
+        text = mock_send.call_args[0][1]
+        assert "No active users" in text
 
     @patch("api.deliver.send_message", side_effect=Exception("network error"))
     def test_swallows_send_errors(self, mock_send):


### PR DESCRIPTION
## Summary

- Splits the combined `"no papers or no active users"` early-exit into two sequential guards, each returning a distinct `reason` code (`no_papers` / `no_active_users`)
- Updates `_notify_owner` with specific, actionable Telegram messages for each new reason so the owner knows exactly which condition failed and what to do next
- Strengthens the two existing early-exit tests with `reason` assertions and adds two new `TestNotifyOwner` cases covering the new message branches

## Test plan

- [ ] All 38 tests in `tests/test_deliver.py` pass (`pytest tests/test_deliver.py -v`)
- [ ] Trigger `/api/deliver` with an empty papers pool → notification reads "No unprocessed papers in pipeline. Check /api/status for pipeline state."
- [ ] Trigger `/api/deliver` with no active users → notification reads "No active users. Send /start to the bot to subscribe."
- [ ] Confirm all other endpoints (`/api/fetch`, `/api/status`, `/api/telegram`, etc.) are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The delivery system now provides more detailed and specific notification messages. When delivery cannot proceed, notifications clearly distinguish whether the issue is due to the absence of papers to process or the absence of active users, enabling better understanding of system status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->