### PR TITLE
feat: add Expand inline button to idea delivery messages

### DIFF
--- a/api/deliver.py
+++ b/api/deliver.py
@@ -173,6 +173,7 @@ def run_deliver(cfg) -> dict:
                     url=url,
                     idea=idea,
                     bot_token=cfg.telegram_bot_token,
+                    expand_enabled=cfg.expand_enabled,
                 )
                 print(f"[deliver] sent to user {user_id}")
             except Exception as e:

--- a/api/spark.py
+++ b/api/spark.py
@@ -106,6 +106,7 @@ def run_spark(user_id: int, chat_id: int, conn, cfg) -> dict:
         url=paper["url"],
         idea=idea,
         bot_token=cfg.telegram_bot_token,
+        expand_enabled=cfg.expand_enabled,
     )
 
     return {"ok": True, "idea_id": idea_id}

--- a/api/telegram.py
+++ b/api/telegram.py
@@ -218,7 +218,7 @@ def handle_callback(cb: dict, conn, cfg, req_ip: str = "unknown"):
     #   "expand:{idea_id}"
     if data.startswith("expand:"):
         parts = data.split(":")
-        if len(parts) == 2 and parts[1].isdigit():
+        if len(parts) == 2 and parts[1].isdigit() and chat_id is not None:
             handle_expand(user_id, chat_id, f"/expand {parts[1]}", conn, cfg)
     elif data.startswith("feedback:"):
         _, idea_id_str, value_str = data.split(":")

--- a/api/telegram.py
+++ b/api/telegram.py
@@ -211,8 +211,16 @@ def handle_callback(cb: dict, conn, cfg, req_ip: str = "unknown"):
             _check_and_apply_auto_suspend(user_id, cb_chat_id, conn, cfg)
         return
 
-    # Expected data format: "feedback:{idea_id}:{value}" where value is 1 or -1
-    if data.startswith("feedback:"):
+    chat_id = cb.get("message", {}).get("chat", {}).get("id")
+
+    # Expected data formats:
+    #   "feedback:{idea_id}:{value}" where value is 1 or -1
+    #   "expand:{idea_id}"
+    if data.startswith("expand:"):
+        parts = data.split(":")
+        if len(parts) == 2 and parts[1].isdigit():
+            handle_expand(user_id, chat_id, f"/expand {parts[1]}", conn, cfg)
+    elif data.startswith("feedback:"):
         _, idea_id_str, value_str = data.split(":")
         idea_id = int(idea_id_str)
         value = int(value_str)

--- a/lib/telegram_client.py
+++ b/lib/telegram_client.py
@@ -34,6 +34,7 @@ def send_idea_message(
     url: str,
     idea: dict,
     bot_token: str,
+    expand_enabled: bool = False,
 ):
     n = idea["novelty_score"]
     f = idea["feasibility_score"]
@@ -49,13 +50,14 @@ def send_idea_message(
         f"`{score_bar}`"
     )
 
-    inline_keyboard = {
-        "inline_keyboard": [[
-            {"text": "\U0001F44D Interesting", "callback_data": f"feedback:{idea_id}:1"},
-            {"text": "\U0001F44E Skip", "callback_data": f"feedback:{idea_id}:-1"},
-            {"text": "\U0001F4C4 Paper", "url": url},
-        ]]
-    }
+    rows = [[
+        {"text": "\U0001F44D Interesting", "callback_data": f"feedback:{idea_id}:1"},
+        {"text": "\U0001F44E Skip", "callback_data": f"feedback:{idea_id}:-1"},
+        {"text": "\U0001F4C4 Paper", "url": url},
+    ]]
+    if expand_enabled:
+        rows.append([{"text": "\U0001F52C Expand", "callback_data": f"expand:{idea_id}"}])
+    inline_keyboard = {"inline_keyboard": rows}
 
     text = _sanitize(text)
 

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -529,10 +529,11 @@ class TestExpandCallback:
     def test_expand_callback_dispatches_to_handle_expand(self, mock_post):
         mock_conn = self._make_conn_with_user()
         cfg = _make_config()
-        cb = {"from": {"id": 123}, "data": "expand:42", "id": "cb1"}
+        cb = {"from": {"id": 123}, "data": "expand:42", "id": "cb1",
+              "message": {"chat": {"id": 456}}}
         with patch("api.telegram.handle_expand") as mock_expand:
             handle_callback(cb, mock_conn, cfg)
-            mock_expand.assert_called_once_with(123, None, "/expand 42", mock_conn, cfg)
+            mock_expand.assert_called_once_with(123, 456, "/expand 42", mock_conn, cfg)
 
     @patch("httpx.post")
     def test_expand_callback_invalid_id_ignored(self, mock_post):

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -13,7 +13,8 @@ from api.telegram import (  # noqa: E402
     handler, handle_message, handle_callback,
     handle_status, handle_topics, handle_pause,
     handle_resume, handle_feedback_summary,
-    handle_spark, handle_report, handle_chat, handle_context
+    handle_spark, handle_report, handle_chat, handle_context,
+    handle_expand,
 )
 
 
@@ -502,9 +503,66 @@ class TestHandleReport:
             mock_conn = MagicMock()
             mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
             mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
-            
+
             cfg = _make_config(github_token="gh_tok", max_github_issues_per_day=3)
             handle_report(123, 456, "/report my email is a@b.com", {}, mock_conn, cfg)
-            
+
             mock_send.assert_called()
             assert "personal information" in mock_send.call_args[0][1]
+
+
+# ---------------------------------------------------------------------------
+# Callback: expand button
+# ---------------------------------------------------------------------------
+
+class TestExpandCallback:
+
+    def _make_conn_with_user(self):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = {"user_id": 123, "paused": False, "pause_until": None}
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_conn
+
+    @patch("httpx.post")
+    def test_expand_callback_dispatches_to_handle_expand(self, mock_post):
+        mock_conn = self._make_conn_with_user()
+        cfg = _make_config()
+        cb = {"from": {"id": 123}, "data": "expand:42", "id": "cb1"}
+        with patch("api.telegram.handle_expand") as mock_expand:
+            handle_callback(cb, mock_conn, cfg)
+            mock_expand.assert_called_once_with(123, None, "/expand 42", mock_conn, cfg)
+
+    @patch("httpx.post")
+    def test_expand_callback_invalid_id_ignored(self, mock_post):
+        mock_conn = self._make_conn_with_user()
+        cfg = _make_config()
+        cb = {"from": {"id": 123}, "data": "expand:abc", "id": "cb2"}
+        with patch("api.telegram.handle_expand") as mock_expand:
+            handle_callback(cb, mock_conn, cfg)
+            mock_expand.assert_not_called()
+
+    @patch("httpx.post")
+    def test_expand_callback_unauthorized_user_ignored(self, mock_post):
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = None  # unknown user
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        cfg = _make_config()
+        cb = {"from": {"id": 99999}, "data": "expand:42", "id": "cb3"}
+        with patch("api.telegram.handle_expand") as mock_expand:
+            handle_callback(cb, mock_conn, cfg)
+            mock_expand.assert_not_called()
+
+    @patch("httpx.post")
+    def test_expand_callback_still_answers_callback_query(self, mock_post):
+        mock_conn = self._make_conn_with_user()
+        cfg = _make_config()
+        cb = {"from": {"id": 123}, "data": "expand:42", "id": "cb-expand"}
+        with patch("api.telegram.handle_expand"):
+            handle_callback(cb, mock_conn, cfg)
+        mock_post.assert_called_once()
+        assert "answerCallbackQuery" in mock_post.call_args[0][0]
+        assert mock_post.call_args[1]["json"]["callback_query_id"] == "cb-expand"

--- a/tests/test_telegram_client.py
+++ b/tests/test_telegram_client.py
@@ -100,6 +100,38 @@ class TestSendIdeaMessage:
         assert len(buttons) == 3
 
     @patch("lib.telegram_client.httpx.post")
+    def test_expand_button_absent_by_default(self, mock_post):
+        mock_post.return_value = MagicMock(raise_for_status=MagicMock())
+        send_idea_message(123, 42, "Title", "https://arxiv.org/abs/123", self._make_idea(), "tok")
+        keyboard = mock_post.call_args[1]["json"]["reply_markup"]["inline_keyboard"]
+        all_callbacks = [b.get("callback_data", "") for row in keyboard for b in row]
+        assert not any(c.startswith("expand:") for c in all_callbacks)
+
+    @patch("lib.telegram_client.httpx.post")
+    def test_expand_button_present_when_enabled(self, mock_post):
+        mock_post.return_value = MagicMock(raise_for_status=MagicMock())
+        send_idea_message(
+            123, 42, "Title", "https://arxiv.org/abs/123", self._make_idea(), "tok",
+            expand_enabled=True,
+        )
+        keyboard = mock_post.call_args[1]["json"]["reply_markup"]["inline_keyboard"]
+        assert len(keyboard) == 2
+        assert keyboard[1][0]["callback_data"] == "expand:42"
+
+    @patch("lib.telegram_client.httpx.post")
+    def test_expand_button_on_second_row(self, mock_post):
+        mock_post.return_value = MagicMock(raise_for_status=MagicMock())
+        send_idea_message(
+            123, 42, "Title", "https://arxiv.org/abs/123", self._make_idea(), "tok",
+            expand_enabled=True,
+        )
+        keyboard = mock_post.call_args[1]["json"]["reply_markup"]["inline_keyboard"]
+        # First row still has 3 buttons
+        assert len(keyboard[0]) == 3
+        # Second row has only the Expand button
+        assert len(keyboard[1]) == 1
+
+    @patch("lib.telegram_client.httpx.post")
     def test_feedback_callback_data_format(self, mock_post):
         mock_post.return_value = MagicMock(raise_for_status=MagicMock())
         send_idea_message(123, 42, "Title", "https://arxiv.org/abs/123", self._make_idea(), "tok")


### PR DESCRIPTION
## Summary

- Adds a 🔬 Expand button as a second keyboard row on every delivered idea message, gated on `cfg.expand_enabled`
- Routes `expand:{idea_id}` callbacks in `handle_callback` to the existing `handle_expand` handler, reusing its caching and rate-limiting logic without any refactoring
- Wires `expand_enabled` through both delivery paths (`deliver.py`, `spark.py`)

## Why

`/expand {id}` was unusable in practice — the idea ID is never surfaced in the delivered message. The inline button embeds the ID in its `callback_data`, so the user can trigger a deep-dive with a single tap.

## Test plan

- [ ] All 54 existing + new tests pass (`pytest tests/test_telegram_client.py tests/test_telegram.py`)
- [ ] Expand button absent when `expand_enabled=False` (default)
- [ ] Expand button appears as second row when `expand_enabled=True`
- [ ] Tapping Expand triggers deep-dive synthesis for that idea
- [ ] Tapping Expand a second time returns the cached response instantly
- [ ] Invalid callback data (`expand:abc`) is silently ignored
- [ ] Unauthorized users are rejected before `handle_expand` is reached

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Expand" button to idea notifications in Telegram, allowing users to view expanded content directly from messages.
  * Expand functionality is now configurable and can be enabled or disabled via settings.

* **Tests**
  * Added comprehensive test coverage for expand button behavior and callback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->