### PR TITLE
fix(chat): repair /chat for papers with curly braces + reliability fixes

### DIFF
--- a/api/telegram.py
+++ b/api/telegram.py
@@ -1,5 +1,6 @@
 import json
 import hmac
+import logging
 import os
 import re
 from http.server import BaseHTTPRequestHandler
@@ -386,16 +387,17 @@ def handle_chat(user_id: int, chat_id: int, text: str, conn, cfg):
         return
 
     context = get_conversation_context(session_id, cfg.chat_context_window, conn)
-    store_message(session_id, "user", user_message, 0, conn)
 
     try:
         response_text, tokens_used = generate_chat_response(
             context, user_message, cfg.chat_model, cfg.openrouter_api_key, cfg.openrouter_timeout
         )
     except Exception:
+        logging.exception("Chat LLM call failed for user_id=%d", user_id)
         send_message(chat_id, "Sorry, I couldn't generate a response. Please try again.", cfg.telegram_bot_token)
         return
 
+    store_message(session_id, "user", user_message, 0, conn)
     store_message(session_id, "assistant", response_text, tokens_used, conn)
     send_message(chat_id, response_text, cfg.telegram_bot_token)
 

--- a/lib/chat.py
+++ b/lib/chat.py
@@ -3,9 +3,14 @@ Chat session management and LLM integration for conversational features.
 """
 
 import json
+import logging
 from datetime import datetime, timezone, timedelta
+from pathlib import Path
 from typing import Optional
 import httpx
+
+_prompts_dir = Path(__file__).resolve().parent.parent / "prompts"
+_CHAT_SYSTEM_TEMPLATE = (_prompts_dir / "chat_system.txt").read_text(encoding="utf-8")
 
 
 def get_or_create_session(user_id: int, paper_id: str | None, idea_id: int | None,
@@ -146,19 +151,15 @@ def generate_chat_response(context: dict, user_message: str,
     Call OpenRouter API with context + new user message.
     Returns (response_text, tokens_used).
     """
-    # Load system prompt template
-    with open("prompts/chat_system.txt", "r", encoding="utf-8") as f:
-        system_template = f.read()
-
-    # Format system prompt
-    system_prompt = system_template.format(
-        title=context["title"],
-        abstract=context["abstract"],
-        hypothesis=context["hypothesis"],
-        method=context["method"],
-        dataset=context["dataset"],
-        novelty_score=context["novelty_score"],
-        feasibility_score=context["feasibility_score"]
+    system_prompt = (
+        _CHAT_SYSTEM_TEMPLATE
+        .replace("{title}", str(context["title"] or ""))
+        .replace("{abstract}", str(context["abstract"] or ""))
+        .replace("{hypothesis}", str(context["hypothesis"] or ""))
+        .replace("{method}", str(context["method"] or ""))
+        .replace("{dataset}", str(context["dataset"] or ""))
+        .replace("{novelty_score}", str(context["novelty_score"] or ""))
+        .replace("{feasibility_score}", str(context["feasibility_score"] or ""))
     )
 
     # Build messages array

--- a/prompts/chat_system.txt
+++ b/prompts/chat_system.txt
@@ -29,4 +29,4 @@ RESPONSE STYLE:
 - Avoid jargon unless necessary
 
 SPECIAL COMMANDS:
-When user says "regenerate", create a new research idea following the same JSON structure: {{hypothesis, method, dataset, novelty_score, feasibility_score}}
+When user says "regenerate", create a new research idea following the same JSON structure: {hypothesis, method, dataset, novelty_score, feasibility_score}

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -37,10 +37,10 @@ def test_generate_chat_response_builds_correct_payload(mock_client_class):
         "usage": {"total_tokens": 100}
     }
     mock_response.raise_for_status = MagicMock()
-    
+
     mock_client_instance = mock_client_class.return_value.__enter__.return_value
     mock_client_instance.post.return_value = mock_response
-    
+
     context = {
         "title": "Paper Title",
         "abstract": "Abstract",
@@ -51,14 +51,12 @@ def test_generate_chat_response_builds_correct_payload(mock_client_class):
         "feasibility_score": 7,
         "messages": [{"role": "user", "content": "Previous hi"}]
     }
-    
-    # Ensure prompts/chat_system.txt exists or mock open
-    with patch("builtins.open", MagicMock(return_value=MagicMock(__enter__=MagicMock(return_value=MagicMock(read=MagicMock(return_value="System {title}")))))):
-        response, tokens = generate_chat_response(context, "New msg", "model", "key", 10)
-    
+
+    response, tokens = generate_chat_response(context, "New msg", "model", "key", 10)
+
     assert response == "Test response"
     assert tokens == 100
-    
+
     # Verify payload
     args, kwargs = mock_client_instance.post.call_args
     payload = kwargs["json"]
@@ -67,3 +65,31 @@ def test_generate_chat_response_builds_correct_payload(mock_client_class):
     assert payload["messages"][0]["role"] == "system"
     assert payload["messages"][1]["content"] == "Previous hi"
     assert payload["messages"][2]["content"] == "New msg"
+
+
+@patch("httpx.Client")
+def test_generate_chat_response_handles_curly_braces_in_paper_content(mock_client_class):
+    """Regression: paper content with {} must not raise KeyError via str.format()."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "choices": [{"message": {"content": "OK"}}],
+        "usage": {"total_tokens": 10}
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_client_instance = mock_client_class.return_value.__enter__.return_value
+    mock_client_instance.post.return_value = mock_response
+
+    context = {
+        "title": "Neural SDEs on {R}^n with {F}-adapted coefficients",
+        "abstract": "We study the class {x | ||x|| < 1} under rough paths.",
+        "hypothesis": "The process {X_t} satisfies the martingale property.",
+        "method": "Ito calculus with {dW_t} increments",
+        "dataset": "Synthetic {OHLCV} tick data",
+        "novelty_score": 8,
+        "feasibility_score": 7,
+        "messages": []
+    }
+
+    # Should not raise — curly braces in content must be treated as literals
+    response, tokens = generate_chat_response(context, "Explain the method.", "model", "key", 10)
+    assert response == "OK"


### PR DESCRIPTION
## Summary

- **Primary bug**: `lib/chat.py` used `str.format()` to render the system prompt. arXiv papers routinely contain `{` and `}` in titles and abstracts (LaTeX notation, set theory, etc.), causing `KeyError`/`ValueError` on every such paper. The bare `except Exception` in `handle_chat` swallowed the error, so users always saw "Sorry, I couldn't generate a response." — making `/chat` appear completely broken.
- **Secondary bug**: The user message was written to the DB *before* the LLM call. Each failed attempt orphaned a message against `message_count`. After 20 orphaned messages the DB `CHECK` constraint caused `store_message` to crash uncaught, propagating through the HTTP handler and making the session permanently broken.
- **Observability**: Added `logging.exception` so LLM failures are now visible in Vercel function logs.

## Changes

| File | What changed |
|------|-------------|
| `lib/chat.py` | Load prompt at module level via `Path(__file__).resolve()` (matches `openrouter.py`); switch `.format()` → chained `.replace()` calls |
| `prompts/chat_system.txt` | Remove `{{...}}` double-brace escaping (only needed for `.format()`) |
| `api/telegram.py` | Move both `store_message` calls to after a successful LLM response; add `logging.exception` |
| `tests/test_chat.py` | Remove now-unnecessary `builtins.open` mock; add curly-brace regression test |

## Test plan

- [ ] `pytest tests/test_chat.py -v` — all 4 tests pass including new curly-brace regression
- [ ] `pytest` — no regressions introduced (pre-existing failures in `test_config`, `test_fetch`, `test_spark`, `test_scaffolding` are unrelated to this change)
- [ ] Manual: send `/chat` against a delivered paper whose abstract contains `{` or `}` — bot responds with LLM output instead of error message