### PR TITLE
fix: roll back undelivered ideas and prevent silent paper consumption on Telegram send failure

### DIFF
--- a/api/deliver.py
+++ b/api/deliver.py
@@ -179,6 +179,17 @@ def run_deliver(cfg) -> dict:
                 print(f"[deliver] failed to send to user {user_id}: {e}")
                 failed_users.append(user_id)
 
+        if len(failed_users) == len(active_users):
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM ideas WHERE id = %s", (idea_id,))
+                conn.commit()
+            _notify_owner(cfg, status="skipped", reason="all_telegram_sends_failed", paper_id=paper_id)
+            return {
+                "sent": 0,
+                "reason": "all_telegram_sends_failed",
+                "details": {"failed_users": len(failed_users)},
+            }
+
         mark_processed(conn, paper_id)
         _notify_owner(cfg, status="sent", idea_id=idea_id, paper_id=paper_id, model=model)
         print(f"[deliver] successfully processed and sent idea {idea_id}")

--- a/api/spark.py
+++ b/api/spark.py
@@ -109,7 +109,10 @@ def run_spark(user_id: int, chat_id: int, conn, cfg) -> dict:
         with conn.cursor() as cur:
             cur.execute("DELETE FROM ideas WHERE id = %s", (idea_id,))
             conn.commit()
-        send_message(chat_id, "Failed to deliver the idea. Please try /spark again.", cfg.telegram_bot_token)
+        try:
+            send_message(chat_id, "Failed to deliver the idea. Please try /spark again.", cfg.telegram_bot_token)
+        except Exception as notify_err:
+            print(f"[spark] failed to send rollback notice: {notify_err}")
         return {"ok": False, "reason": "telegram_send_failed"}
 
     # Mark paper as processed so it won't be selected again

--- a/api/spark.py
+++ b/api/spark.py
@@ -94,19 +94,27 @@ def run_spark(user_id: int, chat_id: int, conn, cfg) -> dict:
 
     idea_id = _store_spark_idea(conn, paper["id"], idea, idea_embedding, user_id)
 
+    try:
+        send_idea_message(
+            chat_id=chat_id,
+            idea_id=idea_id,
+            title=paper["title"],
+            url=paper["url"],
+            idea=idea,
+            bot_token=cfg.telegram_bot_token,
+        )
+    except Exception as e:
+        print(f"[spark] Telegram send failed, rolling back: {e}")
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM ideas WHERE id = %s", (idea_id,))
+            conn.commit()
+        send_message(chat_id, "Failed to deliver the idea. Please try /spark again.", cfg.telegram_bot_token)
+        return {"ok": False, "reason": "telegram_send_failed"}
+
     # Mark paper as processed so it won't be selected again
     with conn.cursor() as cur:
         cur.execute("UPDATE papers SET processed=TRUE WHERE id=%s", (paper["id"],))
         conn.commit()
-
-    send_idea_message(
-        chat_id=chat_id,
-        idea_id=idea_id,
-        title=paper["title"],
-        url=paper["url"],
-        idea=idea,
-        bot_token=cfg.telegram_bot_token,
-    )
 
     return {"ok": True, "idea_id": idea_id}
 

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -423,6 +423,67 @@ class TestRunDeliverSuccess:
 
 
 # ---------------------------------------------------------------------------
+# run_deliver: all Telegram sends fail → rollback and leave paper unprocessed
+# ---------------------------------------------------------------------------
+
+class TestRunDeliverAllSendsFail:
+
+    @patch("api.deliver.mark_processed")
+    @patch("api.deliver.send_idea_message", side_effect=Exception("telegram down"))
+    @patch("api.deliver.store_idea", return_value=77)
+    @patch("api.deliver.is_duplicate", return_value=False)
+    @patch("api.deliver.embed_text", return_value=[0.1] * 1536)
+    @patch("api.deliver.synthesize_idea")
+    @patch("api.deliver.get_connection")
+    @patch("api.deliver.datetime")
+    def test_returns_zero_sent(self, mock_dt, mock_conn_fn, mock_synth, mock_embed,
+                               mock_dedup, mock_store, mock_send, mock_mark):
+        mock_dt.utcnow.return_value = datetime(2024, 1, 15)
+        mock_conn = _mock_conn_with_papers(_make_paper(), [123])
+        mock_conn_fn.return_value = mock_conn
+        mock_synth.return_value = (_make_idea(), "")
+        result = run_deliver(_make_config())
+        assert result["sent"] == 0
+        assert result["reason"] == "all_telegram_sends_failed"
+
+    @patch("api.deliver.mark_processed")
+    @patch("api.deliver.send_idea_message", side_effect=Exception("telegram down"))
+    @patch("api.deliver.store_idea", return_value=77)
+    @patch("api.deliver.is_duplicate", return_value=False)
+    @patch("api.deliver.embed_text", return_value=[0.1] * 1536)
+    @patch("api.deliver.synthesize_idea")
+    @patch("api.deliver.get_connection")
+    @patch("api.deliver.datetime")
+    def test_does_not_mark_processed(self, mock_dt, mock_conn_fn, mock_synth, mock_embed,
+                                     mock_dedup, mock_store, mock_send, mock_mark):
+        mock_dt.utcnow.return_value = datetime(2024, 1, 15)
+        mock_conn = _mock_conn_with_papers(_make_paper(), [123])
+        mock_conn_fn.return_value = mock_conn
+        mock_synth.return_value = (_make_idea(), "")
+        run_deliver(_make_config())
+        mock_mark.assert_not_called()
+
+    @patch("api.deliver.mark_processed")
+    @patch("api.deliver.store_idea", return_value=77)
+    @patch("api.deliver.is_duplicate", return_value=False)
+    @patch("api.deliver.embed_text", return_value=[0.1] * 1536)
+    @patch("api.deliver.synthesize_idea")
+    @patch("api.deliver.get_connection")
+    @patch("api.deliver.datetime")
+    def test_partial_failure_still_marks_processed(self, mock_dt, mock_conn_fn,
+                                                    mock_synth, mock_embed,
+                                                    mock_dedup, mock_store, mock_mark):
+        mock_dt.utcnow.return_value = datetime(2024, 1, 15)
+        mock_conn = _mock_conn_with_papers(_make_paper(), [100, 200, 300])
+        mock_conn_fn.return_value = mock_conn
+        mock_synth.return_value = (_make_idea(), "")
+        with patch("api.deliver.send_idea_message", side_effect=[None, Exception("fail"), None]):
+            result = run_deliver(_make_config())
+        assert result["sent"] == 1
+        mock_mark.assert_called_once_with(mock_conn, "p1")
+
+
+# ---------------------------------------------------------------------------
 # run_deliver: deliver_llm_timeout is used (not openrouter_timeout)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -59,7 +59,7 @@ class TestRunSpark:
     @patch("api.spark.send_message")
     @patch("api.spark._find_paper_for_spark")
     def test_no_papers_sends_message(self, mock_find, mock_send):
-        mock_find.return_value = None
+        mock_find.return_value = (None, {})
         mock_conn, _ = _mock_conn_with_cursor()
         cfg = _make_config()
 
@@ -74,10 +74,8 @@ class TestRunSpark:
     @patch("api.spark.synthesize_idea")
     @patch("api.spark._find_paper_for_spark")
     def test_llm_failure_sends_error(self, mock_find, mock_synth, mock_send):
-        mock_find.return_value = {
-            "id": "2305_12345", "title": "T", "abstract": "A",
-            "url": "https://arxiv.org/abs/2305.12345",
-        }
+        mock_find.return_value = ({"id": "2305_12345", "title": "T", "abstract": "A",
+                                   "url": "https://arxiv.org/abs/2305.12345"}, {})
         mock_synth.return_value = (None, "test debug")
         mock_conn, _ = _mock_conn_with_cursor()
         cfg = _make_config()
@@ -92,10 +90,8 @@ class TestRunSpark:
     @patch("api.spark.synthesize_idea")
     @patch("api.spark._find_paper_for_spark")
     def test_below_quality_gate_sends_error(self, mock_find, mock_synth, mock_send):
-        mock_find.return_value = {
-            "id": "2305_12345", "title": "T", "abstract": "A",
-            "url": "https://arxiv.org/abs/2305.12345",
-        }
+        mock_find.return_value = ({"id": "2305_12345", "title": "T", "abstract": "A",
+                                   "url": "https://arxiv.org/abs/2305.12345"}, {})
         mock_synth.return_value = ({
             "hypothesis": "H", "method": "M", "dataset": "D",
             "novelty_score": 3, "feasibility_score": 3,
@@ -115,10 +111,8 @@ class TestRunSpark:
     @patch("api.spark._find_paper_for_spark")
     def test_success_stores_and_sends_idea(self, mock_find, mock_synth, mock_embed,
                                             mock_store, mock_send_idea):
-        mock_find.return_value = {
-            "id": "2305_12345", "title": "Test Paper", "abstract": "A",
-            "url": "https://arxiv.org/abs/2305.12345",
-        }
+        mock_find.return_value = ({"id": "2305_12345", "title": "Test Paper", "abstract": "A",
+                                   "url": "https://arxiv.org/abs/2305.12345"}, {})
         mock_synth.return_value = ({
             "hypothesis": "H1", "method": "M1", "dataset": "D1",
             "novelty_score": 7, "feasibility_score": 6,
@@ -142,6 +136,37 @@ class TestRunSpark:
         ]
         assert len(update_calls) == 1
 
+    @patch("api.spark.send_message")
+    @patch("api.spark.send_idea_message", side_effect=Exception("telegram down"))
+    @patch("api.spark._store_spark_idea")
+    @patch("api.spark.embed_text")
+    @patch("api.spark.synthesize_idea")
+    @patch("api.spark._find_paper_for_spark")
+    def test_telegram_send_failure_rolls_back(self, mock_find, mock_synth, mock_embed,
+                                               mock_store, mock_send_idea, mock_send_msg):
+        mock_find.return_value = ({"id": "2305_12345", "title": "Test Paper", "abstract": "A",
+                                   "url": "https://arxiv.org/abs/2305.12345"}, {})
+        mock_synth.return_value = ({
+            "hypothesis": "H1", "method": "M1", "dataset": "D1",
+            "novelty_score": 7, "feasibility_score": 6,
+        }, "")
+        mock_embed.return_value = [0.1] * 256
+        mock_store.return_value = 55
+        mock_conn, mock_cursor = _mock_conn_with_cursor()
+        cfg = _make_config()
+
+        result = run_spark(123, 456, mock_conn, cfg)
+
+        assert result["ok"] is False
+        assert result["reason"] == "telegram_send_failed"
+        # Idea is deleted and paper is NOT marked processed
+        delete_calls = [c for c in mock_cursor.execute.call_args_list
+                        if "DELETE FROM ideas" in str(c)]
+        assert len(delete_calls) == 1
+        update_calls = [c for c in mock_cursor.execute.call_args_list
+                        if "UPDATE papers SET processed" in str(c)]
+        assert len(update_calls) == 0
+
 
 # ---------------------------------------------------------------------------
 # _find_paper_for_spark tiers
@@ -155,9 +180,9 @@ class TestFindPaperForSpark:
         mock_cursor.fetchone.return_value = paper_row
         cfg = _make_config()
 
-        result = _find_paper_for_spark(mock_conn, cfg)
+        paper, tiers = _find_paper_for_spark(mock_conn, cfg)
 
-        assert result == paper_row
+        assert paper == paper_row
 
     @patch("api.spark.fetch_recent_papers")
     def test_tier2_excludes_papers_already_in_db(self, mock_fetch):
@@ -180,10 +205,10 @@ class TestFindPaperForSpark:
         mock_fetch.return_value = [arxiv_paper]
         cfg = _make_config()
 
-        result = _find_paper_for_spark(mock_conn, cfg)
+        paper, tiers = _find_paper_for_spark(mock_conn, cfg)
 
         # Paper was in DB so Tier 2 skipped it, Tier 3 also empty → None
-        assert result is None
+        assert paper is None
 
     @patch("api.spark.fetch_recent_papers")
     def test_tier3_returns_random_archived_paper(self, mock_fetch):
@@ -202,9 +227,9 @@ class TestFindPaperForSpark:
         mock_fetch.return_value = []
         cfg = _make_config()
 
-        result = _find_paper_for_spark(mock_conn, cfg)
+        paper, tiers = _find_paper_for_spark(mock_conn, cfg)
 
-        assert result["id"] == "2305_99999"
+        assert paper["id"] == "2305_99999"
 
     @patch("api.spark.fetch_recent_papers")
     def test_tier4_returns_none(self, mock_fetch):
@@ -218,6 +243,6 @@ class TestFindPaperForSpark:
         mock_fetch.return_value = []
         cfg = _make_config()
 
-        result = _find_paper_for_spark(mock_conn, cfg)
+        paper, tiers = _find_paper_for_spark(mock_conn, cfg)
 
-        assert result is None
+        assert paper is None

--- a/tests/test_spark.py
+++ b/tests/test_spark.py
@@ -167,6 +167,30 @@ class TestRunSpark:
                         if "UPDATE papers SET processed" in str(c)]
         assert len(update_calls) == 0
 
+    @patch("api.spark.send_message", side_effect=Exception("also down"))
+    @patch("api.spark.send_idea_message", side_effect=Exception("telegram down"))
+    @patch("api.spark._store_spark_idea")
+    @patch("api.spark.embed_text")
+    @patch("api.spark.synthesize_idea")
+    @patch("api.spark._find_paper_for_spark")
+    def test_rollback_notice_failure_still_returns_clean_result(
+            self, mock_find, mock_synth, mock_embed, mock_store, mock_send_idea, mock_send_msg):
+        mock_find.return_value = ({"id": "2305_12345", "title": "Test Paper", "abstract": "A",
+                                   "url": "https://arxiv.org/abs/2305.12345"}, {})
+        mock_synth.return_value = ({
+            "hypothesis": "H1", "method": "M1", "dataset": "D1",
+            "novelty_score": 7, "feasibility_score": 6,
+        }, "")
+        mock_embed.return_value = [0.1] * 256
+        mock_store.return_value = 55
+        mock_conn, mock_cursor = _mock_conn_with_cursor()
+        cfg = _make_config()
+
+        result = run_spark(123, 456, mock_conn, cfg)
+
+        assert result["ok"] is False
+        assert result["reason"] == "telegram_send_failed"
+
 
 # ---------------------------------------------------------------------------
 # _find_paper_for_spark tiers


### PR DESCRIPTION
## Summary

- **deliver.py**: `mark_processed()` was called unconditionally after the send loop, even when every Telegram send threw an exception. The stored idea (with `sent_at=NOW()`) produced a false "Ideas sent today: 1" in `/status` while the paper was permanently consumed and unreachable by the next cron. Now, if all sends fail, the orphaned idea row is deleted and the function returns early without marking the paper processed — the next scheduled run retries cleanly. Partial failures (at least one user reached) continue to mark the paper processed as before.

- **spark.py**: `mark_processed()` ran *before* `send_idea_message()`, so a Telegram failure permanently consumed the paper while the user received nothing and had no way to retry. Reordered so the idea is stored first, delivery is attempted, and the paper is only marked processed on success. On failure, the idea row is rolled back and the user sees an actionable prompt to retry `/spark`.

- **tests**: adds three new deliver failure-path tests, one new spark rollback test, and fixes four pre-existing spark tests that were passing a plain dict to `run_spark` instead of the `(paper, tiers)` tuple `_find_paper_for_spark` actually returns (they were silently erroring).

## Test plan

- [ ] `python -m pytest tests/test_deliver.py tests/test_spark.py -v` — all 48 tests pass
- [ ] Trigger `/api/deliver` with a bad bot token and confirm the paper remains unprocessed and no row appears in `ideas`
- [ ] Trigger `/spark` with a bad bot token and confirm the idea row is deleted and the user receives an error message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when Telegram delivery fails; the system now automatically rolls back failed operations and notifies users with specific failure reasons.
  * Enhanced handling of partial delivery failures for consistent behavior.

* **Tests**
  * Added comprehensive tests to verify delivery failure scenarios and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->